### PR TITLE
ci: init package.json during commit lint for non-js projects

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: ${{ env.PACKAGE_MANAGER_CACHE }}
+      - name: Init package for non-JS project
+        if: ${{ hashFiles('package.json') == '' }}
+        run: npm init -y
       - name: 'Install Node packages'
         run: $PACKAGE_MANAGER install
       - name: 'Install commit lint config'


### PR DESCRIPTION
Fixes this CI fail: https://github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/actions/runs/9613832940/job/26517379260?pr=72