### PR TITLE
Improve schema cleanup after filtering scopes for `update-sdk-schema` action

### DIFF
--- a/.github/actions/update-sdk-schema/filter-schema.test.ts
+++ b/.github/actions/update-sdk-schema/filter-schema.test.ts
@@ -109,6 +109,17 @@ components:
         - visitorId
         - visits
       title: Response
+    RelatedVisitor:
+      type: object
+      additionalProperties: false
+      required:
+        - visitorId
+      properties:
+        visitorId:
+          type: string
+          description: >-
+            Visitor ID of a browser that originates from the same mobile device
+            as the input visitor ID.
     RelatedVisitorsResponse:
       type: object
       additionalProperties: false

--- a/.github/actions/update-sdk-schema/filter-schema.ts
+++ b/.github/actions/update-sdk-schema/filter-schema.ts
@@ -28,12 +28,17 @@ export function filterSchema(schemaYaml: string, scopes: ScopesMap, allowedScope
     }
   }
 
-  removeUnusedSchemas(schema)
+  let removedCounter = 1
+  while (removedCounter > 0) {
+    removedCounter = removeUnusedSchemas(schema)
+  }
+
   return yaml.dump(schema)
 }
 
 export function removeUnusedSchemas(schema: Record<string, any>) {
   const usageRegistry = new Set<string>()
+  let removedCounter = 0
   walkJson(schema, '$ref', (usage) => {
     const componentName = usage['$ref']
     usageRegistry.add(componentName)
@@ -44,8 +49,10 @@ export function removeUnusedSchemas(schema: Record<string, any>) {
     if (!usageRegistry.has(`#/components/schemas/${componentName}`)) {
       console.info(`Removing component ${componentName}`)
       delete components[componentName]
+      removedCounter++
     }
   }
+  return removedCounter
 }
 
 function walkJson(json: Record<string, any>, key: string, callback: (json: Record<string, any>) => void) {


### PR DESCRIPTION
It was a bug with cleaning up unused models after schema filtering.
I applied a simple solution: scan the schema again and again untill we have something to remove