### PR TITLE
Update regex to handle both quoted styles in changesets

### DIFF
--- a/.github/actions/update-sdk-schema/changesets.test.ts
+++ b/.github/actions/update-sdk-schema/changesets.test.ts
@@ -1,7 +1,7 @@
 import { getChangesetScope, replacePackageName } from './changesets'
 
 describe('replacePackageName', () => {
-  it('replaces package name', () => {
+  it('replaces package name with single quote', () => {
     const changeset = `---
 'fingerprint-pro-server-api-openapi': patch
 ---
@@ -16,6 +16,24 @@ describe('replacePackageName', () => {
       ---
 
       **events**: Test patch change"
+    `)
+  })
+
+  it('replaces package name with double quotes', () => {
+    const changeset = `---
+"fingerprint-pro-server-api-openapi": minor
+---
+
+Add \`mitmAttack\` (man-in-the-middle attack) Smart Signal.`
+
+    const result = replacePackageName(changeset, 'test-package')
+
+    expect(result).toMatchInlineSnapshot(`
+      "---
+      "test-package": minor
+      ---
+
+      Add \`mitmAttack\` (man-in-the-middle attack) Smart Signal."
     `)
   })
 })

--- a/.github/actions/update-sdk-schema/changesets.ts
+++ b/.github/actions/update-sdk-schema/changesets.ts
@@ -26,7 +26,8 @@ export function getChangesetScope(changeset: string) {
 }
 
 export function replacePackageName(changeset: string, name: string) {
-  const regex = /---\n'(.*)':/
+  // Match either single or double-quoted package name
+  const regex = /---\n['"](.*)['"]:/
   const match = regex.exec(changeset)
 
   if (!match) {

--- a/.github/actions/update-sdk-schema/dist/index.js
+++ b/.github/actions/update-sdk-schema/dist/index.js
@@ -49061,7 +49061,8 @@ function getChangesetScope(changeset) {
     return null;
 }
 function replacePackageName(changeset, name) {
-    const regex = /---\n'(.*)':/;
+    // Match either single or double-quoted package name
+    const regex = /---\n['"](.*)['"]:/;
     const match = regex.exec(changeset);
     if (!match) {
         return changeset;


### PR DESCRIPTION
This PR updates the regex in `replacePackageName` to support both single-quoted and double-quoted styles. 