### PR TITLE
Add support for custom plugins in analyze-commits workflow

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -22,6 +22,23 @@ on:
         type: boolean
         default: true
         required: false
+      semanticReleasePlugins:
+        description: 'Additional Semantic Release plugins (one per line)'
+        type: string
+        required: false
+        default: ''
+      prepareCommand:
+        description: 'Command to run for project preparation (e.g., installing dependencies).'
+        required: false
+        type: string
+      setupLanguage:
+        description: 'Programming language for the project. Supported values are "java", "dotnet", "python", "golang", "flutter" and "php".'
+        required: false
+        type: string
+      setupLanguageVersion:
+        description: 'Version of the programming language to setup.'
+        required: false
+        type: string
 
 jobs:
   commitlint:
@@ -116,9 +133,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.nodeVersion }}
+      - name: Setup language
+        if: ${{ inputs.setupLanguage && inputs.setupLanguageVersion }}
+        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        with:
+          language: ${{ inputs.setupLanguage }}
+          language-version: ${{ inputs.setupLanguageVersion }}
+      - name: Prepare project
+        if: ${{ inputs.prepareCommand }}
+        run: ${{ inputs.prepareCommand }}
       - name: Collect semantic-release-info
         id: semantic_release_info
         uses: fingerprintjs/action-semantic-release-info@v2
+        with:
+          semanticReleasePlugins: ${{ inputs.semanticReleasePlugins }}
       - if: ${{ steps.semantic_release_info.outputs.no_release == 'false' }}
         name: Add comment to the PR
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ structure.
 | `nodeVersion`                   | No       | String | `lts/*` | Node version to use                                                                                                                              |
 | `installSharedCommitLintConfig` | No       | Bool   | `true`  | Whether to install our shared commit lint config. If set to `true` it will run `npm i @fingerprintjs/commit-lint-dx-team@latest` before linting. |
 | `previewNotes`                  | No       | Bool   | `true`  | Whether to generate preview of the release notes                                                                                                 |
+| `semanticReleasePlugins`        | No       | String | `''`    | Additional Semantic Release plugins to install and include (one per line)                                                                        |
+| `prepareCommand`                | No       | String | `''`    | Command to run for project preparation                                                                                                           |
+| `setupLanguage`                 | No       | String | `''`    | Setup project for specific programming language. Supported values are `java`, `dotnet`, `python`, `golang`, `flutter`, and `php`.                |
+| `setupLanguageVersion`          | No       | String | `''`    | Version of the programming language to set up.                                                                                                   | 
 
 #### Example of usage:
 


### PR DESCRIPTION
This update improves the `analyze-commits` GH Action workflow by introducing new input parameters: `semanticReleasePlugins`, `prepareCommand`, `setupLanguage`, and `setupLanguageVersion`.

Related-Task: INTER-1238