### PR TITLE
feat: add set-datadog-team reusable workflow

### DIFF
--- a/.github/workflows/set-datadog-team.yml
+++ b/.github/workflows/set-datadog-team.yml
@@ -1,0 +1,22 @@
+name: 'Set the team tag in DataDog for the workflow results'
+on:
+  workflow_call:
+    secrets:
+      DD_API_KEY:
+        required: true
+
+jobs:
+  set_datadog_team:
+    name: 'Set the team tag in DataDog for the workflow results'
+    runs-on: ubuntu-latest
+    steps:
+      # Install the DD CLI directly from GitHub instead of using npmjs.com. Downloading from
+      # GitHub is significantly faster.
+      - name: 'Install the DataDog CLI'
+        run: |
+          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "$RUNNER_TEMP/datadog-ci" && chmod +x "$RUNNER_TEMP/datadog-ci"
+      - name: 'Set the team tag for the pipeline in DataDog'
+        run: |
+          "$RUNNER_TEMP/datadog-ci" tag --no-fail --level pipeline --tags team:integrations
+        env:
+          DD_API_KEY: '${{ secrets.DD_API_KEY }}'


### PR DESCRIPTION
Add the set-datadog-team reusable workflow. The workflow sets the team to integrations in DataDog for the running workflow using the datadog-ci tool. The datadog-ci tool is installed from DataDog's releases on the datadog-ci repository.

Tested with [this PR for the node SDK](https://github.com/fingerprintjs/fingerprintjs-pro-server-api-node-sdk/pull/195)

References:
- https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_measures/?tab=linux