### PR TITLE
feat: add additional, optional tags parameter to set-datadog-team

### DIFF
--- a/.github/workflows/set-datadog-team.yml
+++ b/.github/workflows/set-datadog-team.yml
@@ -1,13 +1,18 @@
-name: 'Set the team tag in DataDog for the workflow results'
+name: 'Set the team tag and additional, optional tags in DataDog for the workflow results'
 on:
   workflow_call:
+    inputs:
+      additionalTags:
+        description: 'Comma-separated list of additional Datadog tags to set (e.g., release-version:1.3.1)'
+        required: false
+        type: string
     secrets:
       DD_API_KEY:
         required: true
 
 jobs:
-  set_datadog_team:
-    name: 'Set the team tag in DataDog for the workflow results'
+  set_datadog_tags:
+    name: 'Set the team tag and additional, optional tags in DataDog for the workflow results'
     runs-on: ubuntu-latest
     steps:
       # Install the DD CLI directly from GitHub instead of using npmjs.com. Downloading from
@@ -15,8 +20,21 @@ jobs:
       - name: 'Install the DataDog CLI'
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "$RUNNER_TEMP/datadog-ci" && chmod +x "$RUNNER_TEMP/datadog-ci"
-      - name: 'Set the team tag for the pipeline in DataDog'
+      - name: 'Set the team tag and additional, optional tags for the pipeline in DataDog'
         run: |
-          "$RUNNER_TEMP/datadog-ci" tag --no-fail --level pipeline --tags team:integrations
+          # Convert the additionalTags input into the format: --tags tag1:value1 --tags tag2:value2
+          TAG_ARGS=""
+          if [ -n "${{ inputs.additionalTags }}" ]; then
+            IFS=',' read -ra TAGS <<< "${{ inputs.additionalTags }}"
+            for tag in "${TAGS[@]}"; do
+              # Trim whitespace
+              tag_trimmed="$(echo "$tag" | xargs)"
+
+              TAG_ARGS="$TAG_ARGS --tags $tag_trimmed"
+            done
+          fi
+
+          # Set the tags
+          "$RUNNER_TEMP/datadog-ci" tag --no-fail --level pipeline --tags team:integrations $TAG_ARGS
         env:
           DD_API_KEY: '${{ secrets.DD_API_KEY }}'

--- a/.github/workflows/test-set-datadog-team.yml
+++ b/.github/workflows/test-set-datadog-team.yml
@@ -1,0 +1,13 @@
+name: Test Set Datadog Team Workflow
+
+on:
+  pull_request:
+
+jobs:
+  test-set-datadog-team:
+    name: Test Set Datadog Team
+    uses: ./.github/workflows/set-datadog-team.yml
+    with:
+      additionalTags: dx-team-toolkit-test-tag:${{ github.event.number }}
+    secrets:
+      DD_API_KEY: ${{ secrets.INTEGRATIONS_DATADOG_API_KEY }}


### PR DESCRIPTION
Add an input parameter to set-datadog-team to allow additional tags to
be set along with the team for the current top-level workflow in
Datadog.

This will allow workflows to add additional tags that can be
used by Datadog resources to refine the queries they use to identify
specific GitHub Actions workflows.

For example, the orchestra e2e test run for a server SDK release can
add a tag like `release-version:v6.7.0` and then a specific Datadog
monitor can be triggered when that test run completes.

