### PR TITLE
chore: remove unused SLACK_WEBHOOK_URL

### DIFF
--- a/.github/workflows/run-server-sdk-e2e-tests.yml
+++ b/.github/workflows/run-server-sdk-e2e-tests.yml
@@ -23,9 +23,6 @@ on:
       APP_PRIVATE_KEY:
         description: 'GitHub App token to request GitHub token'
         required: true
-      SLACK_WEBHOOK_URL:
-        description: 'Slack webhook URL for sending job status'
-        required: true
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
Remove `SLACK_WEBHOOK_URL` secret parameter from
`run-server-sdk-e2e-tests` as it is no longer used.