### PR TITLE
feat: migrate dx-toolkit release to npm trusted publishing INTER-2138

### DIFF
--- a/.github/workflows/release-dx-packages.yml
+++ b/.github/workflows/release-dx-packages.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -27,6 +32,10 @@ jobs:
           node-version: 20.x
           cache: pnpm
 
+      # Ensure npm 11.5.1 or later is installed for trusted publishing
+      - name: Update npm
+        run: npm i -g npm@^11.5.1 && npm --version
+
       - name: Install Dependencies
         run: pnpm install
 
@@ -40,11 +49,10 @@ jobs:
         run: pnpm test
 
       - name: Create Release
-        uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9
+        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
         with:
           publish: pnpm changeset publish
           commit: 'chore(release): changeset created a new release'
           title: 'Release packages [changeset]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/packages/changesets-changelog-format/package.json
+++ b/packages/changesets-changelog-format/package.json
@@ -8,6 +8,10 @@
   },
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "dist/index.js",
   "files": [
     "dist/index.js"

--- a/packages/commit-lint-dx-team/package.json
+++ b/packages/commit-lint-dx-team/package.json
@@ -9,6 +9,10 @@
   },
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "index.js",
   "files": [
     "index.js"

--- a/packages/conventional-changelog-dx-team/package.json
+++ b/packages/conventional-changelog-dx-team/package.json
@@ -9,6 +9,10 @@
   },
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "index.js",
   "files": [
     "index.js",

--- a/packages/eslint-config-dx-team/package.json
+++ b/packages/eslint-config-dx-team/package.json
@@ -9,6 +9,10 @@
   },
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "index.js",
   "files": [
     "index.js",

--- a/packages/prettier-config-dx-team/package.json
+++ b/packages/prettier-config-dx-team/package.json
@@ -9,6 +9,10 @@
   },
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "index.js",
   "files": [
     "index.js"

--- a/packages/tsconfig-dx-team/package.json
+++ b/packages/tsconfig-dx-team/package.json
@@ -9,6 +9,10 @@
   },
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "files": [
     "tsconfig.json"
   ]


### PR DESCRIPTION
## Summary
- Replace `NPM_AUTH_TOKEN` secret with OIDC-based npm trusted publishing, eliminating the need for long-lived npm tokens
- Add `id-token: write` permission for OIDC, install npm 11.5.1+ (required for trusted publishing)
- Update `changesets/action` to v1.6.0 (aligned with reusable `release-sdk-changesets.yml`)

Follows the same pattern as `fingerprintjs/vue` ([release.yml](https://github.com/fingerprintjs/vue/blob/main/.github/workflows/release.yml)).

## Before merging
Someone with npm admin access on `@fingerprintjs` needs to configure Trusted Publishers on npmjs.com for each package:
- `@fingerprintjs/conventional-changelog-dx-team`
- `@fingerprintjs/changesets-changelog-format`
- `@fingerprintjs/prettier-config-dx-team`
- `@fingerprintjs/eslint-config-dx-team`
- `@fingerprintjs/commit-lint-dx-team`
- `@fingerprintjs/tsconfig-dx-team`

Each should be configured with:
- **Repository:** `fingerprintjs/dx-team-toolkit`
- **Workflow:** `release-dx-packages.yml`
- **Environment:** `production-npm`