### PR TITLE
INTER-1921: accept `sdkPackageName` input for server sdk e2e tests

### DIFF
--- a/.github/workflows/run-server-sdk-e2e-tests.yml
+++ b/.github/workflows/run-server-sdk-e2e-tests.yml
@@ -15,6 +15,11 @@ on:
         type: string
         required: true
         description: 'GitHub app id to access the repository with E2E tests'
+      sdkPackageName:
+        description: 'Custom package name for old SDK versions'
+        required: false
+        default: ''
+        type: string
       commitSha:
         type: string
         required: false
@@ -46,6 +51,7 @@ jobs:
           client-payload: |-
             {
               "sdk-version": "${{ inputs.sdkVersion }}",
+              "package-name": "${{ inputs.sdkPackageName }}",
               "run-node-sdk-tests": ${{ inputs.sdk == 'node' }},
               "run-go-sdk-tests": ${{ inputs.sdk == 'go' }},
               "run-dotnet-sdk-tests": ${{ inputs.sdk == 'dotnet' }},


### PR DESCRIPTION
Accepts `sdkPackageName` input for the `run-server-sdk-e2e-tests` workflow and passes it to the `dx-team-orchestra` `e2e_tests` workflow with `package-name` parameter.