### PR TITLE
feat: add prepare-command to changeset preview workflow

### DIFF
--- a/.github/workflows/preview-changeset-release.yml
+++ b/.github/workflows/preview-changeset-release.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: 'pnpm exec changeset'
+      prepare-command:
+        description: 'Command to run for project preparation (e.g., installing dependencies).'
+        required: false
+        type: string
 
 jobs:
   preview:
@@ -49,6 +53,10 @@ jobs:
 
       - name: Install dependencies
         run: $PACKAGE_MANAGER install
+
+      - name: Prepare project
+        if: ${{ inputs.prepare-command }}
+        run: ${{ inputs.prepare-command }}
 
       - name: 'Get release notes'
         id: notes

--- a/README.md
+++ b/README.md
@@ -691,6 +691,19 @@ release notes.
 
 1. Project is properly configured to release using changesets.
 
+#### Workflow Inputs
+
+The workflow accepts the following input parameters:
+
+<!-- prettier-ignore -->
+
+| Input Parameter     | Required | Type   | Default              | Description                                                                                       |
+|---------------------|----------|--------|----------------------|---------------------------------------------------------------------------------------------------|
+| `pr-title`          | Yes      | String | -                    | Title of created PR                                                                               |
+| `node-version`      | No       | String | `lts/*`              | Node version to use                                                                               |
+| `changeset-command` | No       | String | `pnpm exec changeset`| Command used to generate changeset. It will be used in a suggestion if there are no changesets.   |
+| `prepare-command`   | No       | String | -                    | Command(s) to run for project preparation, such as installing dependencies.                       |
+
 #### Example of usage:
 
 ```yaml

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "prepare": "husky install",
     "build": "pnpm run -r build",
     "build:actions": "bash ./scripts/build-actions.sh",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
+    "test": "jest --runInBand",
+    "test:coverage": "jest --runInBand --coverage",
     "docs": "mkdir docs && cp README.md ./docs/README.md",
     "lint:fix": "pnpm run lint --fix",
     "lint": "eslint --ext .ts,.js --ignore-path .gitignore --max-warnings 0 . .github/actions"


### PR DESCRIPTION
This PR adds `prepare-command` option to the changeset preview workflow.

Note: I've missed that my last PR caused some tests to fail. The original error was:
```
EEXIST: file already exists, mkdir '/tmp/test-pkg-tidy-clowns-stay'
```
This PR addresses that by running the tests sequentially via `--runInBand` but until this PR is merged the "Check coverage action" will fail.