### PR TITLE
Add paths-changed composite action for required checks

### DIFF
--- a/.github/actions/paths-changed/README.md
+++ b/.github/actions/paths-changed/README.md
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   check-broken-links:
@@ -74,11 +73,7 @@ jobs:
 
 | Input               | Required | Default              | Description                                               |
 |---------------------|----------|----------------------|-----------------------------------------------------------|
-| `paths`             | Yes      | -                    | Newline-separated positive picomatch globs.               |
-| `base`              | No       | _(auto)_             | Base ref. Defaults to the PR base branch / previous push commit. |
-| `ref`               | No       | _(auto)_             | Head ref. Defaults to the current ref.                    |
-| `working-directory` | No       | `.`                  | Checkout path under `$GITHUB_WORKSPACE`.                  |
-| `token`             | No       | job token            | Token for pull request file lookup.                       |
+| `paths`             | Yes      | -                    | Newline-separated positive git glob pathspecs.            |
 
 ## Outputs
 
@@ -87,18 +82,12 @@ jobs:
 | Output          | Description                                              |
 |-----------------|----------------------------------------------------------|
 | `changed`       | `'true'` when any watched path changed.                  |
-| `changed-files` | Space-separated, shell-escaped matching changed files.   |
 
 ## Filter Syntax
 
-`paths` accepts positive [picomatch](https://github.com/micromatch/picomatch) globs such
-as `src/**`, `*.md`, and `{package.json,pnpm-lock.yaml}`.
-
-This action wraps one [`dorny/paths-filter`](https://github.com/dorny/paths-filter) filter.
-Use `dorny/paths-filter` directly for advanced YAML, change-type rules such as
-`added|modified`, or exclusion logic like `!src/**/*.md`.
+`paths` accepts positive [git glob pathspecs](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec)
+such as `src/**`, `*.md`, and `package.json`.
 
 ## Permissions
 
-For `pull_request` workflows, grant `pull-requests: read`. If the job checks out the repo,
-also grant `contents: read`.
+Grant `contents: read` so the job can check out the repo and fetch the comparison ref.

--- a/.github/actions/paths-changed/README.md
+++ b/.github/actions/paths-changed/README.md
@@ -78,7 +78,7 @@ jobs:
 | `base`              | No       | _(auto)_             | Base ref. Defaults to the PR base branch / previous push commit. |
 | `ref`               | No       | _(auto)_             | Head ref. Defaults to the current ref.                    |
 | `working-directory` | No       | `.`                  | Checkout path under `$GITHUB_WORKSPACE`.                  |
-| `token`             | No       | `${{ github.token }}` | Token for pull request file lookup.                       |
+| `token`             | No       | job token            | Token for pull request file lookup.                       |
 
 ## Outputs
 

--- a/.github/actions/paths-changed/README.md
+++ b/.github/actions/paths-changed/README.md
@@ -6,6 +6,8 @@ Use this when a required check should always report, but its expensive steps onl
 run for some files. Let the workflow run on every PR, then gate the expensive steps on this
 action's `changed` output.
 
+## Gate Steps
+
 ```yaml
 name: Check broken links
 
@@ -35,6 +37,35 @@ jobs:
       - name: Check broken links
         if: steps.changes.outputs.changed == 'true'
         run: pnpm check:broken-links
+```
+
+## Gate a Downstream Job
+
+Use a small always-running job to expose the `changed` output, then skip heavier jobs from
+there.
+
+```yaml
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run-e2e: ${{ steps.changes.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: changes
+        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1
+        with:
+          paths: |
+            src/**
+            plugins/**
+            .github/workflows/**
+
+  e2e:
+    needs: changes
+    if: needs.changes.outputs.run-e2e == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./run-e2e.sh
 ```
 
 ## Inputs

--- a/.github/actions/paths-changed/README.md
+++ b/.github/actions/paths-changed/README.md
@@ -37,11 +37,11 @@ action packages that pattern so nobody has to write it again.
 
 | Input               | Required | Default            | Description                                                                                          |
 |---------------------|----------|--------------------|------------------------------------------------------------------------------------------------------|
-| `paths`             | Yes      | -                  | Newline-separated list of glob patterns to watch (same syntax as GitHub's built-in `paths:` filter). |
+| `paths`             | Yes      | -                  | Newline-separated list of positive picomatch glob patterns to watch.                                 |
 | `base`              | No       | _(auto)_           | Base ref of the comparison. Defaults to the PR base branch / previous commit.                        |
 | `ref`               | No       | _(auto)_           | Head ref of the comparison. Defaults to the current ref.                                             |
 | `working-directory` | No       | `.`                | Relative path under `$GITHUB_WORKSPACE` to run the detection in.                                     |
-| `token`             | No       | `${{ github.token }}` | Token used to fetch changed files for `push` events via the API.                                  |
+| `token`             | No       | `${{ github.token }}` | Token used to fetch changed files for pull request events via the API.                            |
 
 ## Outputs
 
@@ -59,6 +59,10 @@ name: Check broken links
 
 on:
   pull_request: # no `paths:` filter — the workflow always runs
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   check-broken-links:
@@ -89,6 +93,10 @@ reports success, and is mergeable.
 ```yaml
 on:
   pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   changes:
@@ -121,5 +129,11 @@ jobs:
 
 - Built on top of [`dorny/paths-filter`](https://github.com/dorny/paths-filter), which
   handles the `pull_request` vs `push` diff semantics and shallow checkouts.
-- Glob syntax follows [picomatch](https://github.com/micromatch/picomatch) (e.g. `**`,
-  `*`, `{a,b}`), matching the syntax used by GitHub's native `paths:` filter.
+- For `pull_request` workflows, grant `pull-requests: read`. If the workflow also checks
+  out the repository, grant `contents: read`.
+- The `paths` input accepts positive [picomatch](https://github.com/micromatch/picomatch)
+  glob patterns such as `src/**`, `*.md`, and `{package.json,pnpm-lock.yaml}`. This action
+  wraps one [`dorny/paths-filter`](https://github.com/dorny/paths-filter) filter, so do not
+  use GitHub trigger-style ordered exclusion patterns like `!src/**/*.md` here. Use
+  `dorny/paths-filter` directly when you need advanced filter YAML, change-type rules such
+  as `added|modified`, or exclusion semantics.

--- a/.github/actions/paths-changed/README.md
+++ b/.github/actions/paths-changed/README.md
@@ -1,64 +1,16 @@
 # `paths-changed` action
 
-Detect whether a pull request or push touched any of a set of path globs — **without**
-breaking required status checks.
+Detect changed files without using workflow-level `paths:` filters.
 
-## The problem it solves
-
-GitHub lets you skip a workflow when only irrelevant files change by adding a `paths:`
-filter to the trigger:
-
-```yaml
-on:
-  pull_request:
-    paths:
-      - 'src/**'
-```
-
-But if that workflow's check is marked as **required** in branch protection, a PR that
-touches none of those paths (for example a `README.md`-only change) will never run the
-check — and GitHub blocks the merge forever, waiting for a status that will never report.
-
-Teams keep re-implementing the same workaround by hand (see the ad-hoc `git diff` jobs in
-`fastly-compute-proxy` and the `dorny/paths-filter` job in `fingerprintjs/docs`). This
-action packages that pattern so nobody has to write it again.
-
-## How it works
-
-1. **Do not** put a `paths:` filter on your trigger, so the workflow always runs and the
-   required check always reports a status.
-2. Run this action to detect whether any watched path actually changed.
-3. Gate the expensive steps on the `changed` output. When nothing relevant changed, the
-   job still completes successfully and the required check goes green.
-
-## Inputs
-
-<!-- prettier-ignore -->
-
-| Input               | Required | Default            | Description                                                                                          |
-|---------------------|----------|--------------------|------------------------------------------------------------------------------------------------------|
-| `paths`             | Yes      | -                  | Newline-separated list of positive picomatch glob patterns to watch.                                 |
-| `base`              | No       | _(auto)_           | Base ref of the comparison. Defaults to the PR base branch / previous commit.                        |
-| `ref`               | No       | _(auto)_           | Head ref of the comparison. Defaults to the current ref.                                             |
-| `working-directory` | No       | `.`                | Relative path under `$GITHUB_WORKSPACE` to run the detection in.                                     |
-| `token`             | No       | `${{ github.token }}` | Token used to fetch changed files for pull request events via the API.                            |
-
-## Outputs
-
-<!-- prettier-ignore -->
-
-| Output          | Description                                                                          |
-|-----------------|--------------------------------------------------------------------------------------|
-| `changed`       | `'true'` if any of the watched paths changed, otherwise `'false'`.                   |
-| `changed-files` | Space-separated, shell-escaped list of the changed files that matched the patterns.  |
-
-## Example: a required check that only runs heavy work when relevant files change
+Use this when a required check should always report, but its expensive steps only need to
+run for some files. Let the workflow run on every PR, then gate the expensive steps on this
+action's `changed` output.
 
 ```yaml
 name: Check broken links
 
 on:
-  pull_request: # no `paths:` filter — the workflow always runs
+  pull_request:
 
 permissions:
   contents: read
@@ -66,12 +18,12 @@ permissions:
 
 jobs:
   check-broken-links:
-    name: Check broken links # mark THIS job as the required status check
+    name: Check broken links
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - id: filter
+      - id: changes
         uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1
         with:
           paths: |
@@ -81,59 +33,41 @@ jobs:
             .github/workflows/**
 
       - name: Check broken links
-        if: steps.filter.outputs.changed == 'true'
+        if: steps.changes.outputs.changed == 'true'
         run: pnpm check:broken-links
 ```
 
-A `README.md`-only PR now still runs the `check-broken-links` job, skips the heavy step,
-reports success, and is mergeable.
+## Inputs
 
-## Example: gate a whole downstream job
+<!-- prettier-ignore -->
 
-```yaml
-on:
-  pull_request:
+| Input               | Required | Default              | Description                                               |
+|---------------------|----------|----------------------|-----------------------------------------------------------|
+| `paths`             | Yes      | -                    | Newline-separated positive picomatch globs.               |
+| `base`              | No       | _(auto)_             | Base ref. Defaults to the PR base branch / previous push commit. |
+| `ref`               | No       | _(auto)_             | Head ref. Defaults to the current ref.                    |
+| `working-directory` | No       | `.`                  | Checkout path under `$GITHUB_WORKSPACE`.                  |
+| `token`             | No       | `${{ github.token }}` | Token for pull request file lookup.                       |
 
-permissions:
-  contents: read
-  pull-requests: read
+## Outputs
 
-jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      run-e2e: ${{ steps.filter.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: filter
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1
-        with:
-          paths: |
-            src/**
-            plugins/**
-            .github/workflows/**
+<!-- prettier-ignore -->
 
-  e2e:
-    needs: changes
-    if: needs.changes.outputs.run-e2e == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - run: ./run-e2e.sh
-```
+| Output          | Description                                              |
+|-----------------|----------------------------------------------------------|
+| `changed`       | `'true'` when any watched path changed.                  |
+| `changed-files` | Space-separated, shell-escaped matching changed files.   |
 
-> **Note:** when you gate a whole job with `if:` and that job is a required check, GitHub
-> treats the skipped job as passed. Gating individual steps (the first example) is the most
-> robust because the job always runs to completion.
+## Filter Syntax
 
-## Notes
+`paths` accepts positive [picomatch](https://github.com/micromatch/picomatch) globs such
+as `src/**`, `*.md`, and `{package.json,pnpm-lock.yaml}`.
 
-- Built on top of [`dorny/paths-filter`](https://github.com/dorny/paths-filter), which
-  handles the `pull_request` vs `push` diff semantics and shallow checkouts.
-- For `pull_request` workflows, grant `pull-requests: read`. If the workflow also checks
-  out the repository, grant `contents: read`.
-- The `paths` input accepts positive [picomatch](https://github.com/micromatch/picomatch)
-  glob patterns such as `src/**`, `*.md`, and `{package.json,pnpm-lock.yaml}`. This action
-  wraps one [`dorny/paths-filter`](https://github.com/dorny/paths-filter) filter, so do not
-  use GitHub trigger-style ordered exclusion patterns like `!src/**/*.md` here. Use
-  `dorny/paths-filter` directly when you need advanced filter YAML, change-type rules such
-  as `added|modified`, or exclusion semantics.
+This action wraps one [`dorny/paths-filter`](https://github.com/dorny/paths-filter) filter.
+Use `dorny/paths-filter` directly for advanced YAML, change-type rules such as
+`added|modified`, or exclusion logic like `!src/**/*.md`.
+
+## Permissions
+
+For `pull_request` workflows, grant `pull-requests: read`. If the job checks out the repo,
+also grant `contents: read`.

--- a/.github/actions/paths-changed/README.md
+++ b/.github/actions/paths-changed/README.md
@@ -1,0 +1,125 @@
+# `paths-changed` action
+
+Detect whether a pull request or push touched any of a set of path globs — **without**
+breaking required status checks.
+
+## The problem it solves
+
+GitHub lets you skip a workflow when only irrelevant files change by adding a `paths:`
+filter to the trigger:
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+```
+
+But if that workflow's check is marked as **required** in branch protection, a PR that
+touches none of those paths (for example a `README.md`-only change) will never run the
+check — and GitHub blocks the merge forever, waiting for a status that will never report.
+
+Teams keep re-implementing the same workaround by hand (see the ad-hoc `git diff` jobs in
+`fastly-compute-proxy` and the `dorny/paths-filter` job in `fingerprintjs/docs`). This
+action packages that pattern so nobody has to write it again.
+
+## How it works
+
+1. **Do not** put a `paths:` filter on your trigger, so the workflow always runs and the
+   required check always reports a status.
+2. Run this action to detect whether any watched path actually changed.
+3. Gate the expensive steps on the `changed` output. When nothing relevant changed, the
+   job still completes successfully and the required check goes green.
+
+## Inputs
+
+<!-- prettier-ignore -->
+
+| Input               | Required | Default            | Description                                                                                          |
+|---------------------|----------|--------------------|------------------------------------------------------------------------------------------------------|
+| `paths`             | Yes      | -                  | Newline-separated list of glob patterns to watch (same syntax as GitHub's built-in `paths:` filter). |
+| `base`              | No       | _(auto)_           | Base ref of the comparison. Defaults to the PR base branch / previous commit.                        |
+| `ref`               | No       | _(auto)_           | Head ref of the comparison. Defaults to the current ref.                                             |
+| `working-directory` | No       | `.`                | Relative path under `$GITHUB_WORKSPACE` to run the detection in.                                     |
+| `token`             | No       | `${{ github.token }}` | Token used to fetch changed files for `push` events via the API.                                  |
+
+## Outputs
+
+<!-- prettier-ignore -->
+
+| Output          | Description                                                                          |
+|-----------------|--------------------------------------------------------------------------------------|
+| `changed`       | `'true'` if any of the watched paths changed, otherwise `'false'`.                   |
+| `changed-files` | Space-separated, shell-escaped list of the changed files that matched the patterns.  |
+
+## Example: a required check that only runs heavy work when relevant files change
+
+```yaml
+name: Check broken links
+
+on:
+  pull_request: # no `paths:` filter — the workflow always runs
+
+jobs:
+  check-broken-links:
+    name: Check broken links # mark THIS job as the required status check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: filter
+        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1
+        with:
+          paths: |
+            mintlify/**
+            package.json
+            pnpm-lock.yaml
+            .github/workflows/**
+
+      - name: Check broken links
+        if: steps.filter.outputs.changed == 'true'
+        run: pnpm check:broken-links
+```
+
+A `README.md`-only PR now still runs the `check-broken-links` job, skips the heavy step,
+reports success, and is mergeable.
+
+## Example: gate a whole downstream job
+
+```yaml
+on:
+  pull_request:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run-e2e: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1
+        with:
+          paths: |
+            src/**
+            plugins/**
+            .github/workflows/**
+
+  e2e:
+    needs: changes
+    if: needs.changes.outputs.run-e2e == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./run-e2e.sh
+```
+
+> **Note:** when you gate a whole job with `if:` and that job is a required check, GitHub
+> treats the skipped job as passed. Gating individual steps (the first example) is the most
+> robust because the job always runs to completion.
+
+## Notes
+
+- Built on top of [`dorny/paths-filter`](https://github.com/dorny/paths-filter), which
+  handles the `pull_request` vs `push` diff semantics and shallow checkouts.
+- Glob syntax follows [picomatch](https://github.com/micromatch/picomatch) (e.g. `**`,
+  `*`, `{a,b}`), matching the syntax used by GitHub's native `paths:` filter.

--- a/.github/actions/paths-changed/action.yml
+++ b/.github/actions/paths-changed/action.yml
@@ -1,0 +1,90 @@
+name: 'Paths changed'
+description: >-
+  Detect whether a pull request or push touched any of the given path globs while
+  still always reporting a status, so the check can safely be marked as required.
+  Solves GitHub's "skipped but required" problem: keep your workflow trigger free
+  of `paths:` filters so the job always runs, then gate the expensive steps on the
+  `changed` output of this action.
+
+inputs:
+  paths:
+    description: >-
+      Newline-separated list of glob patterns to watch. Uses the same syntax as
+      GitHub's built-in `paths:` filter. Example:
+        paths: |
+          src/**
+          package.json
+          .github/workflows/**
+    required: true
+  base:
+    description: >-
+      Git reference (branch, tag or SHA) to use as the base of the comparison.
+      Defaults to the PR base branch for `pull_request` events and to the
+      previous commit for `push` events. You usually do not need to set this.
+    required: false
+    default: ''
+  ref:
+    description: >-
+      Git reference (branch, tag or SHA) to use as the head of the comparison.
+      Defaults to the current ref. You usually do not need to set this.
+    required: false
+    default: ''
+  working-directory:
+    description: 'Relative path under $GITHUB_WORKSPACE to run the detection in.'
+    required: false
+    default: '.'
+  token:
+    description: >-
+      GitHub token used to fetch the list of changed files for `push` events via
+      the API. Defaults to the job token.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  changed:
+    description: "'true' if any of the watched paths changed, otherwise 'false'."
+    value: ${{ steps.filter.outputs.changed }}
+  changed-files:
+    description: >-
+      Space-separated, shell-escaped list of the changed files that matched the
+      watched paths.
+    value: ${{ steps.filter.outputs.changed_files }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Build path filter
+      id: build-filter
+      shell: bash
+      env:
+        PATHS: ${{ inputs.paths }}
+      run: |
+        if [ -z "${PATHS//[[:space:]]/}" ]; then
+          echo "::error::The 'paths' input must contain at least one glob pattern."
+          exit 1
+        fi
+        {
+          echo 'filters<<__PATHS_CHANGED_EOF__'
+          echo 'changed:'
+          while IFS= read -r pattern; do
+            # Trim surrounding whitespace
+            pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+            pattern="${pattern%"${pattern##*[![:space:]]}"}"
+            [ -z "$pattern" ] && continue
+            # Escape single quotes so the pattern is safe inside single-quoted YAML
+            escaped="${pattern//\'/\'\'}"
+            echo "  - '${escaped}'"
+          done <<< "$PATHS"
+          echo '__PATHS_CHANGED_EOF__'
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Detect changed paths
+      id: filter
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      with:
+        base: ${{ inputs.base }}
+        ref: ${{ inputs.ref }}
+        working-directory: ${{ inputs.working-directory }}
+        token: ${{ inputs.token }}
+        list-files: shell
+        filters: ${{ steps.build-filter.outputs.filters }}

--- a/.github/actions/paths-changed/action.yml
+++ b/.github/actions/paths-changed/action.yml
@@ -9,8 +9,10 @@ description: >-
 inputs:
   paths:
     description: >-
-      Newline-separated list of glob patterns to watch. Uses the same syntax as
-      GitHub's built-in `paths:` filter. Example:
+      Newline-separated list of positive picomatch glob patterns to watch. This
+      wrapper passes the list to one dorny/paths-filter filter, so prefer include
+      patterns here. Use dorny/paths-filter directly for advanced filter YAML,
+      change-type rules, or exclusion semantics. Example:
         paths: |
           src/**
           package.json
@@ -35,8 +37,8 @@ inputs:
     default: '.'
   token:
     description: >-
-      GitHub token used to fetch the list of changed files for `push` events via
-      the API. Defaults to the job token.
+      GitHub token used to fetch the list of changed files for pull request
+      events via the API. Defaults to the job token.
     required: false
     default: ${{ github.token }}
 
@@ -72,7 +74,7 @@ runs:
             pattern="${pattern%"${pattern##*[![:space:]]}"}"
             [ -z "$pattern" ] && continue
             # Escape single quotes so the pattern is safe inside single-quoted YAML
-            escaped="${pattern//\'/\'\'}"
+            escaped="${pattern//\'/''}"
             echo "  - '${escaped}'"
           done <<< "$PATHS"
           echo '__PATHS_CHANGED_EOF__'

--- a/.github/actions/paths-changed/action.yml
+++ b/.github/actions/paths-changed/action.yml
@@ -1,18 +1,13 @@
 name: 'Paths changed'
 description: >-
-  Detect whether a pull request or push touched any of the given path globs while
-  still always reporting a status, so the check can safely be marked as required.
-  Solves GitHub's "skipped but required" problem: keep your workflow trigger free
-  of `paths:` filters so the job always runs, then gate the expensive steps on the
-  `changed` output of this action.
+  Detect changed paths while still letting required checks report a status.
 
 inputs:
   paths:
     description: >-
-      Newline-separated list of positive picomatch glob patterns to watch. This
-      wrapper passes the list to one dorny/paths-filter filter, so prefer include
-      patterns here. Use dorny/paths-filter directly for advanced filter YAML,
-      change-type rules, or exclusion semantics. Example:
+      Newline-separated positive picomatch globs. This wrapper creates one
+      dorny/paths-filter filter; use dorny/paths-filter directly for advanced
+      filters, change-type rules, or exclusions. Example:
         paths: |
           src/**
           package.json
@@ -22,13 +17,13 @@ inputs:
     description: >-
       Git reference (branch, tag or SHA) to use as the base of the comparison.
       Defaults to the PR base branch for `pull_request` events and to the
-      previous commit for `push` events. You usually do not need to set this.
+      previous commit for `push` events.
     required: false
     default: ''
   ref:
     description: >-
       Git reference (branch, tag or SHA) to use as the head of the comparison.
-      Defaults to the current ref. You usually do not need to set this.
+      Defaults to the current ref.
     required: false
     default: ''
   working-directory:
@@ -37,19 +32,18 @@ inputs:
     default: '.'
   token:
     description: >-
-      GitHub token used to fetch the list of changed files for pull request
-      events via the API. Defaults to the job token.
+      GitHub token used to fetch changed files for pull request events. Defaults
+      to the job token.
     required: false
     default: ${{ github.token }}
 
 outputs:
   changed:
-    description: "'true' if any of the watched paths changed, otherwise 'false'."
+    description: "'true' when any watched path changed."
     value: ${{ steps.filter.outputs.changed }}
   changed-files:
     description: >-
-      Space-separated, shell-escaped list of the changed files that matched the
-      watched paths.
+      Space-separated, shell-escaped list of matching changed files.
     value: ${{ steps.filter.outputs.changed_files }}
 
 runs:

--- a/.github/actions/paths-changed/action.yml
+++ b/.github/actions/paths-changed/action.yml
@@ -32,10 +32,10 @@ inputs:
     default: '.'
   token:
     description: >-
-      GitHub token used to fetch changed files for pull request events. Defaults
-      to the job token.
+      GitHub token used to fetch changed files for pull request events. Falls
+      back to the job token.
     required: false
-    default: ${{ github.token }}
+    default: ''
 
 outputs:
   changed:
@@ -68,7 +68,7 @@ runs:
             pattern="${pattern%"${pattern##*[![:space:]]}"}"
             [ -z "$pattern" ] && continue
             # Escape single quotes so the pattern is safe inside single-quoted YAML
-            escaped="${pattern//\'/''}"
+            escaped="$(printf '%s' "$pattern" | sed "s/'/''/g")"
             echo "  - '${escaped}'"
           done <<< "$PATHS"
           echo '__PATHS_CHANGED_EOF__'
@@ -81,6 +81,6 @@ runs:
         base: ${{ inputs.base }}
         ref: ${{ inputs.ref }}
         working-directory: ${{ inputs.working-directory }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.token || github.token }}
         list-files: shell
         filters: ${{ steps.build-filter.outputs.filters }}

--- a/.github/actions/paths-changed/action.yml
+++ b/.github/actions/paths-changed/action.yml
@@ -5,82 +5,70 @@ description: >-
 inputs:
   paths:
     description: >-
-      Newline-separated positive picomatch globs. This wrapper creates one
-      dorny/paths-filter filter; use dorny/paths-filter directly for advanced
-      filters, change-type rules, or exclusions. Example:
+      Newline-separated positive git glob pathspecs. Example:
         paths: |
           src/**
           package.json
           .github/workflows/**
     required: true
-  base:
-    description: >-
-      Git reference (branch, tag or SHA) to use as the base of the comparison.
-      Defaults to the PR base branch for `pull_request` events and to the
-      previous commit for `push` events.
-    required: false
-    default: ''
-  ref:
-    description: >-
-      Git reference (branch, tag or SHA) to use as the head of the comparison.
-      Defaults to the current ref.
-    required: false
-    default: ''
-  working-directory:
-    description: 'Relative path under $GITHUB_WORKSPACE to run the detection in.'
-    required: false
-    default: '.'
-  token:
-    description: >-
-      GitHub token used to fetch changed files for pull request events. Falls
-      back to the job token.
-    required: false
-    default: ''
 
 outputs:
   changed:
     description: "'true' when any watched path changed."
-    value: ${{ steps.filter.outputs.changed }}
-  changed-files:
-    description: >-
-      Space-separated, shell-escaped list of matching changed files.
-    value: ${{ steps.filter.outputs.changed_files }}
+    value: ${{ steps.detect.outputs.changed }}
 
 runs:
   using: 'composite'
   steps:
-    - name: Build path filter
-      id: build-filter
+    - name: Detect changed paths
+      id: detect
       shell: bash
       env:
         PATHS: ${{ inputs.paths }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
+        set -euo pipefail
+
         if [ -z "${PATHS//[[:space:]]/}" ]; then
           echo "::error::The 'paths' input must contain at least one glob pattern."
           exit 1
         fi
-        {
-          echo 'filters<<__PATHS_CHANGED_EOF__'
-          echo 'changed:'
-          while IFS= read -r pattern; do
-            # Trim surrounding whitespace
-            pattern="${pattern#"${pattern%%[![:space:]]*}"}"
-            pattern="${pattern%"${pattern##*[![:space:]]}"}"
-            [ -z "$pattern" ] && continue
-            # Escape single quotes so the pattern is safe inside single-quoted YAML
-            escaped="$(printf '%s' "$pattern" | sed "s/'/''/g")"
-            echo "  - '${escaped}'"
-          done <<< "$PATHS"
-          echo '__PATHS_CHANGED_EOF__'
-        } >> "$GITHUB_OUTPUT"
 
-    - name: Detect changed paths
-      id: filter
-      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-      with:
-        base: ${{ inputs.base }}
-        ref: ${{ inputs.ref }}
-        working-directory: ${{ inputs.working-directory }}
-        token: ${{ inputs.token || github.token }}
-        list-files: shell
-        filters: ${{ steps.build-filter.outputs.filters }}
+        if [ -z "${GITHUB_BASE_REF:-}" ]; then
+          echo "::error::This action requires a pull_request workflow event."
+          exit 1
+        fi
+
+        cd "$GITHUB_WORKSPACE"
+
+        # Prefer the exact PR base SHA from the event. The base branch can move
+        # while the PR is open, and comparing against the new tip over-reports.
+        git fetch --no-tags --depth=1 origin "${PR_BASE_SHA:-$GITHUB_BASE_REF}"
+        base="$(git rev-parse FETCH_HEAD)"
+
+        # Convert each input line into a git glob pathspec, keeping the action
+        # deliberately narrower than full `git diff` pathspec syntax.
+        pathspecs=()
+        while IFS= read -r pattern; do
+          pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+          pattern="${pattern%"${pattern##*[![:space:]]}"}"
+          [ -z "$pattern" ] && continue
+          if [[ "$pattern" == '!'* ]]; then
+            echo "::error::The 'paths' input only supports positive git glob pathspecs."
+            exit 1
+          fi
+          pathspecs+=(":(glob)$pattern")
+        done <<< "$PATHS"
+
+        set +e
+        git diff --quiet --diff-filter=ACMRT "$base" -- "${pathspecs[@]}"
+        diff_status=$?
+        set -e
+
+        if [ "$diff_status" -eq 0 ]; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        elif [ "$diff_status" -eq 1 ]; then
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        else
+          exit "$diff_status"
+        fi

--- a/.github/workflows/test-paths-changed.yml
+++ b/.github/workflows/test-paths-changed.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   test-paths-changed:
@@ -43,56 +42,5 @@ jobs:
           fi
           if [ "${{ steps.no-match.outputs.changed }}" != "false" ]; then
             echo "::error::Expected 'changed' to be 'false' for a non-existent path"
-            exit 1
-          fi
-
-      - name: Create local diff fixture
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mkdir -p paths-changed-fixture/matched paths-changed-fixture/ignored
-          echo "matched" > paths-changed-fixture/matched/file.txt
-          echo "ignored" > paths-changed-fixture/ignored/file.txt
-
-          git add paths-changed-fixture
-
-      - name: Run action with a matching local git diff
-        id: local-match
-        uses: ./.github/actions/paths-changed
-        with:
-          base: HEAD
-          paths: |
-            paths-changed-fixture/matched/**
-
-      - name: Run action with a non-matching local git diff
-        id: local-no-match
-        uses: ./.github/actions/paths-changed
-        with:
-          base: HEAD
-          paths: |
-            paths-changed-fixture/missing/**
-
-      - name: Assert local git diff outputs
-        shell: bash
-        run: |
-          echo "local-match.changed=${{ steps.local-match.outputs.changed }}"
-          echo "local-match.changed-files=${{ steps.local-match.outputs.changed-files }}"
-          echo "local-no-match.changed=${{ steps.local-no-match.outputs.changed }}"
-          echo "local-no-match.changed-files=${{ steps.local-no-match.outputs.changed-files }}"
-          if [ "${{ steps.local-match.outputs.changed }}" != "true" ]; then
-            echo "::error::Expected local git diff fixture to match"
-            exit 1
-          fi
-          if [ "${{ steps.local-match.outputs.changed-files }}" != "paths-changed-fixture/matched/file.txt" ]; then
-            echo "::error::Expected only the matched fixture file in 'changed-files'"
-            exit 1
-          fi
-          if [ "${{ steps.local-no-match.outputs.changed }}" != "false" ]; then
-            echo "::error::Expected missing fixture path not to match"
-            exit 1
-          fi
-          if [ -n "${{ steps.local-no-match.outputs.changed-files }}" ]; then
-            echo "::error::Expected no changed files for missing fixture path"
             exit 1
           fi

--- a/.github/workflows/test-paths-changed.yml
+++ b/.github/workflows/test-paths-changed.yml
@@ -5,6 +5,10 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test-paths-changed:
     name: Test paths-changed action

--- a/.github/workflows/test-paths-changed.yml
+++ b/.github/workflows/test-paths-changed.yml
@@ -1,0 +1,43 @@
+name: Test paths-changed action
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  test-paths-changed:
+    name: Test paths-changed action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # A PR always changes at least one file, so '**' must always match.
+      - name: Run action with a matching pattern
+        id: match
+        uses: ./.github/actions/paths-changed
+        with:
+          paths: |
+            **
+
+      # No file lives under this path, so it must never match.
+      - name: Run action with a non-matching pattern
+        id: no-match
+        uses: ./.github/actions/paths-changed
+        with:
+          paths: |
+            this/path/does/not/exist/**
+
+      - name: Assert outputs
+        shell: bash
+        run: |
+          echo "match.changed=${{ steps.match.outputs.changed }}"
+          echo "no-match.changed=${{ steps.no-match.outputs.changed }}"
+          if [ "${{ steps.match.outputs.changed }}" != "true" ]; then
+            echo "::error::Expected 'changed' to be 'true' for the '**' pattern"
+            exit 1
+          fi
+          if [ "${{ steps.no-match.outputs.changed }}" != "false" ]; then
+            echo "::error::Expected 'changed' to be 'false' for a non-existent path"
+            exit 1
+          fi

--- a/.github/workflows/test-paths-changed.yml
+++ b/.github/workflows/test-paths-changed.yml
@@ -45,3 +45,54 @@ jobs:
             echo "::error::Expected 'changed' to be 'false' for a non-existent path"
             exit 1
           fi
+
+      - name: Create local diff fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p paths-changed-fixture/matched paths-changed-fixture/ignored
+          echo "matched" > paths-changed-fixture/matched/file.txt
+          echo "ignored" > paths-changed-fixture/ignored/file.txt
+
+          git add paths-changed-fixture
+
+      - name: Run action with a matching local git diff
+        id: local-match
+        uses: ./.github/actions/paths-changed
+        with:
+          base: HEAD
+          paths: |
+            paths-changed-fixture/matched/**
+
+      - name: Run action with a non-matching local git diff
+        id: local-no-match
+        uses: ./.github/actions/paths-changed
+        with:
+          base: HEAD
+          paths: |
+            paths-changed-fixture/missing/**
+
+      - name: Assert local git diff outputs
+        shell: bash
+        run: |
+          echo "local-match.changed=${{ steps.local-match.outputs.changed }}"
+          echo "local-match.changed-files=${{ steps.local-match.outputs.changed-files }}"
+          echo "local-no-match.changed=${{ steps.local-no-match.outputs.changed }}"
+          echo "local-no-match.changed-files=${{ steps.local-no-match.outputs.changed-files }}"
+          if [ "${{ steps.local-match.outputs.changed }}" != "true" ]; then
+            echo "::error::Expected local git diff fixture to match"
+            exit 1
+          fi
+          if [ "${{ steps.local-match.outputs.changed-files }}" != "paths-changed-fixture/matched/file.txt" ]; then
+            echo "::error::Expected only the matched fixture file in 'changed-files'"
+            exit 1
+          fi
+          if [ "${{ steps.local-no-match.outputs.changed }}" != "false" ]; then
+            echo "::error::Expected missing fixture path not to match"
+            exit 1
+          fi
+          if [ -n "${{ steps.local-no-match.outputs.changed-files }}" ]; then
+            echo "::error::Expected no changed files for missing fixture path"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -796,11 +796,20 @@ output instead.
 
 | Input Parameter     | Required | Type   | Default               | Description                                                                                          |
 |---------------------|----------|--------|-----------------------|------------------------------------------------------------------------------------------------------|
-| `paths`             | Yes      | String | -                     | Newline-separated list of glob patterns to watch (same syntax as GitHub's built-in `paths:` filter). |
+| `paths`             | Yes      | String | -                     | Newline-separated list of positive picomatch glob patterns to watch.                                 |
 | `base`              | No       | String | _(auto)_              | Base ref of the comparison. Defaults to the PR base branch / previous commit.                        |
 | `ref`               | No       | String | _(auto)_              | Head ref of the comparison. Defaults to the current ref.                                             |
 | `working-directory` | No       | String | `.`                   | Relative path under `$GITHUB_WORKSPACE` to run the detection in.                                     |
-| `token`             | No       | String | `${{ github.token }}` | Token used to fetch changed files for `push` events via the API.                                     |
+| `token`             | No       | String | `${{ github.token }}` | Token used to fetch changed files for pull request events via the API.                               |
+
+#### Filter syntax
+
+Use positive [picomatch](https://github.com/micromatch/picomatch) glob patterns such as
+`src/**`, `*.md`, and `{package.json,pnpm-lock.yaml}`. This action wraps one
+[`dorny/paths-filter`](https://github.com/dorny/paths-filter) filter, so do not use GitHub
+trigger-style ordered exclusion patterns like `!src/**/*.md` here. Use `dorny/paths-filter`
+directly when you need advanced filter YAML, change-type rules such as `added|modified`,
+or exclusion semantics.
 
 #### Outputs
 
@@ -818,6 +827,10 @@ name: Check broken links
 
 on:
   pull_request: # no `paths:` filter — the workflow always runs
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   check-broken-links:

--- a/README.md
+++ b/README.md
@@ -775,83 +775,9 @@ jobs:
 
 ## Reusable actions
 
-- [1. Detect changed paths without breaking required checks](#1-detect-changed-paths-without-breaking-required-checks)
+- [1. Detect changed paths](#1-detect-changed-paths)
 
-### 1. Detect changed paths without breaking required checks
+### 1. Detect changed paths
 
-The [`paths-changed`](.github/actions/paths-changed) composite action tells you whether a
-pull request or push touched any of a set of path globs, so you can run expensive steps
-only when relevant files change — **without** the "skipped but required" problem.
-
-Adding a `paths:` filter to a workflow trigger skips the workflow entirely when no matching
-file changes. If that check is _required_ by branch protection, the PR is then blocked
-forever waiting for a status that never reports (e.g. a `README.md`-only change against a
-workflow that only watches `src/**`). The fix is to keep the trigger free of `paths:`
-filters so the check always runs, and gate the heavy steps on this action's `changed`
-output instead.
-
-#### Inputs
-
-<!-- prettier-ignore -->
-
-| Input Parameter     | Required | Type   | Default               | Description                                                                                          |
-|---------------------|----------|--------|-----------------------|------------------------------------------------------------------------------------------------------|
-| `paths`             | Yes      | String | -                     | Newline-separated list of positive picomatch glob patterns to watch.                                 |
-| `base`              | No       | String | _(auto)_              | Base ref of the comparison. Defaults to the PR base branch / previous commit.                        |
-| `ref`               | No       | String | _(auto)_              | Head ref of the comparison. Defaults to the current ref.                                             |
-| `working-directory` | No       | String | `.`                   | Relative path under `$GITHUB_WORKSPACE` to run the detection in.                                     |
-| `token`             | No       | String | `${{ github.token }}` | Token used to fetch changed files for pull request events via the API.                               |
-
-#### Filter syntax
-
-Use positive [picomatch](https://github.com/micromatch/picomatch) glob patterns such as
-`src/**`, `*.md`, and `{package.json,pnpm-lock.yaml}`. This action wraps one
-[`dorny/paths-filter`](https://github.com/dorny/paths-filter) filter, so do not use GitHub
-trigger-style ordered exclusion patterns like `!src/**/*.md` here. Use `dorny/paths-filter`
-directly when you need advanced filter YAML, change-type rules such as `added|modified`,
-or exclusion semantics.
-
-#### Outputs
-
-<!-- prettier-ignore -->
-
-| Output          | Description                                                                          |
-|-----------------|--------------------------------------------------------------------------------------|
-| `changed`       | `'true'` if any of the watched paths changed, otherwise `'false'`.                   |
-| `changed-files` | Space-separated, shell-escaped list of the changed files that matched the patterns.  |
-
-#### Example of usage:
-
-```yaml
-name: Check broken links
-
-on:
-  pull_request: # no `paths:` filter — the workflow always runs
-
-permissions:
-  contents: read
-  pull-requests: read
-
-jobs:
-  check-broken-links:
-    name: Check broken links # mark THIS job as the required status check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: filter
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1
-        with:
-          paths: |
-            mintlify/**
-            package.json
-            pnpm-lock.yaml
-            .github/workflows/**
-
-      - name: Check broken links
-        if: steps.filter.outputs.changed == 'true'
-        run: pnpm check:broken-links
-```
-
-See the [action README](.github/actions/paths-changed) for more examples, including gating
-a whole downstream job.
+Use [`paths-changed`](.github/actions/paths-changed) to keep required checks reporting
+while skipping expensive steps when watched files did not change.

--- a/README.md
+++ b/README.md
@@ -772,3 +772,73 @@ jobs:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
+
+## Reusable actions
+
+- [1. Detect changed paths without breaking required checks](#1-detect-changed-paths-without-breaking-required-checks)
+
+### 1. Detect changed paths without breaking required checks
+
+The [`paths-changed`](.github/actions/paths-changed) composite action tells you whether a
+pull request or push touched any of a set of path globs, so you can run expensive steps
+only when relevant files change — **without** the "skipped but required" problem.
+
+Adding a `paths:` filter to a workflow trigger skips the workflow entirely when no matching
+file changes. If that check is _required_ by branch protection, the PR is then blocked
+forever waiting for a status that never reports (e.g. a `README.md`-only change against a
+workflow that only watches `src/**`). The fix is to keep the trigger free of `paths:`
+filters so the check always runs, and gate the heavy steps on this action's `changed`
+output instead.
+
+#### Inputs
+
+<!-- prettier-ignore -->
+
+| Input Parameter     | Required | Type   | Default               | Description                                                                                          |
+|---------------------|----------|--------|-----------------------|------------------------------------------------------------------------------------------------------|
+| `paths`             | Yes      | String | -                     | Newline-separated list of glob patterns to watch (same syntax as GitHub's built-in `paths:` filter). |
+| `base`              | No       | String | _(auto)_              | Base ref of the comparison. Defaults to the PR base branch / previous commit.                        |
+| `ref`               | No       | String | _(auto)_              | Head ref of the comparison. Defaults to the current ref.                                             |
+| `working-directory` | No       | String | `.`                   | Relative path under `$GITHUB_WORKSPACE` to run the detection in.                                     |
+| `token`             | No       | String | `${{ github.token }}` | Token used to fetch changed files for `push` events via the API.                                     |
+
+#### Outputs
+
+<!-- prettier-ignore -->
+
+| Output          | Description                                                                          |
+|-----------------|--------------------------------------------------------------------------------------|
+| `changed`       | `'true'` if any of the watched paths changed, otherwise `'false'`.                   |
+| `changed-files` | Space-separated, shell-escaped list of the changed files that matched the patterns.  |
+
+#### Example of usage:
+
+```yaml
+name: Check broken links
+
+on:
+  pull_request: # no `paths:` filter — the workflow always runs
+
+jobs:
+  check-broken-links:
+    name: Check broken links # mark THIS job as the required status check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: filter
+        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1
+        with:
+          paths: |
+            mintlify/**
+            package.json
+            pnpm-lock.yaml
+            .github/workflows/**
+
+      - name: Check broken links
+        if: steps.filter.outputs.changed == 'true'
+        run: pnpm check:broken-links
+```
+
+See the [action README](.github/actions/paths-changed) for more examples, including gating
+a whole downstream job.


### PR DESCRIPTION
- Adds `paths-changed`, a small composite action for required PR checks that must always report while skipping expensive work when watched files did not change.
- Uses native `git fetch` + `git diff --quiet`; no third-party filtering action.
- Supports positive git glob pathspecs and exposes one output: `changed`.
- Documents step and downstream-job gating examples.

### Validation

- `git diff --check`
- workflow/action YAML parsed with Ruby
- local shell check against this PR base SHA: `**` => `changed=true`, nonexistent path => `changed=false`
- external e2e in `fingerprintjs/fastly-compute-proxy`: [test workflow file](https://github.com/fingerprintjs/fastly-compute-proxy/blob/d597c54c88ae5d3cf719be7628c932c235b60eb3/.github/workflows/build.yml) and [passing test job](https://github.com/fingerprintjs/fastly-compute-proxy/actions/runs/27695334961/job/81916903016)

### Context

https://fingerprintjs.slack.com/archives/C050TKU9X5L/p1781693546144329