### PR TITLE
INTER-2221: Bump third-party actions for `setup-lang`

### DIFF
--- a/.github/actions/setup-lang/action.yml
+++ b/.github/actions/setup-lang/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - name: 'Install PHP'
       if: ${{ inputs.language == 'php' }}
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
       with:
         php-version: ${{ inputs.language-version }}
         coverage: none

--- a/.github/actions/setup-lang/action.yml
+++ b/.github/actions/setup-lang/action.yml
@@ -45,14 +45,14 @@ runs:
 
     - name: 'Install Flutter'
       if: ${{ inputs.language == 'flutter' }}
-      uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
+      uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
       with:
         flutter-version: ${{ inputs.language-version }}
         channel: 'stable'
 
     - name: 'Install PHP'
       if: ${{ inputs.language == 'php' }}
-      uses: shivammathur/setup-php@6d7209f44a25a59e904b1ee9f3b0c33ab2cd888d
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ inputs.language-version }}
         coverage: none
@@ -60,7 +60,7 @@ runs:
 
     - name: 'Install Terraform'
       if: ${{ inputs.language == 'terraform' }}
-      uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       with:
         terraform_version: ${{ inputs.language-version }}
 
@@ -72,7 +72,7 @@ runs:
 
     - name: 'Setup pnpm'
       if: ${{ inputs.language == 'node' }}
-      uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
         version: 9
         run_install: 'true'


### PR DESCRIPTION
## Summary

- **`pnpm/action-setup`**: `v3.0.0` to `v6.0.9` (was [using Node 20](https://github.com/pnpm/action-setup/blob/129abb77bf5884e578fcaf1f37628e41622cc371/action.yml#L27), causing deprecation warnings in CI)
- **`hashicorp/setup-terraform`**: `v3.1.1` to `v4.0.1` (was [using Node20](https://github.com/hashicorp/setup-terraform/blob/651471c36a6092792c552e8b1bef71e592b462d8/action.yml#L21), causing deprecation warnings in CI)
- **`shivammathur/setup-php`**: `2.29.0` to `2.37.2` (was [using Node20](https://github.com/shivammathur/setup-php/blob/6d7209f44a25a59e904b1ee9f3b0c33ab2cd888d/action.yml#L34), causing deprecation warnings in CI)
- **`subosito/flutter-action`**: `v2.12.0` to `v2.23.0`

## What changed and why

**`pnpm/action-setup`**, **`hashicorp/setup-terraform`**, and **`shivammathur/setup-php`** all there used `runs.using: node20` internally. GitHub has deprecated Node 20 in GH Actions, so these produced a deprecation warning on every workflow run that set up a node or terraform language.

**`subosito/flutter-action`** is a composite (bash-based) action with no Node runtime; bumped for bug fixes and improvements.

No inputs or outputs of the `setup-lang` composite action itself changed. The `version`, `run_install`, `terraform_version`, `php-version`, and `flutter-version` inputs all work identically in the new versions.

## Affected action/workflow consumers

Only workflows that call `fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1` are affected. That is the `release-server-sdk.yml`, `release-sdk-changesets.yml`, and `update-server-side-sdk-schema.yml` reusable workflows (and their consumers).

## Test plan

- [ ] `test-reusable-workflows.yml` passes