### PR TITLE
INTER-2225: Replace remote self-referencing with local action paths

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -139,7 +139,7 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
       - name: Setup language
         if: ${{ inputs.setupLanguage && inputs.setupLanguageVersion }}
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./.github/actions/setup-lang
         with:
           language: ${{ inputs.setupLanguage }}
           language-version: ${{ inputs.setupLanguageVersion }}

--- a/.github/workflows/preview-changeset-release.yml
+++ b/.github/workflows/preview-changeset-release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: 'Get release notes'
         id: notes
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/changeset-release-notes@v1
+        uses: ./.github/actions/changeset-release-notes
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Determine changesets step
         id: changeset-determine-step
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/changeset-determine-step@v1
+        uses: ./.github/actions/changeset-determine-step
   create-pr:
     runs-on: ubuntu-latest
     needs: determine-changesets-step
@@ -111,7 +111,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup language
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
@@ -160,7 +160,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup language
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup language
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -114,7 +114,7 @@ jobs:
           repository: ${{ inputs.owner }}/${{ inputs.repository }}
 
       - name: Setup language
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
@@ -137,7 +137,7 @@ jobs:
           git config --global --add --bool push.autoSetupRemote true
 
       - name: Update schema
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/update-sdk-schema@v1
+        uses: ./.github/actions/update-sdk-schema
         with:
           schemaSource: ${{ inputs.schema-source }}
           schemaPath: ${{ inputs.schema-path }}


### PR DESCRIPTION
## Summary

Replace remote `fingerprintjs/dx-team-toolkit/.github/actions/...@v1` references inside reusable workflows with local `./.github/actions/...` paths.

## Why

Remote self-references always resolve to the **published `@v1` tag**, regardless of which branch the workflow is running on. This made it impossible to verify composite action changes during PR review. CI would silently run the old version.

This was discovered while testing the [action upgrade PR](#159).

Local paths (`./.github/actions/...`) inside a called workflow always resolve within **dx-team-toolkit at whatever ref the workflow was fetched from**. On a feature branch, that's the branch itself; for external consumers calling `@v1` it's still `@v1`. Co behaviour is identical after the merge.