### PR TITLE
INTER-2221: Bump core GH Actions and pnpm

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -49,7 +49,7 @@ jobs:
     name: Analyze Commit Messages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: 'Determine package manager'
@@ -69,11 +69,11 @@ jobs:
           fi
       - if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
         name: 'Install pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
       - name: 'Install latest node version'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: ${{ env.PACKAGE_MANAGER_CACHE }}
@@ -130,11 +130,11 @@ jobs:
     env:
       TEST_MESSAGE: ${{ inputs.isTest && '### ⚠️ This is a test run of the release-notes-comment action that can be found in .github/workflows/analyze-commits.yml' || ''}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: 'Install latest node version'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.nodeVersion }}
       - name: Setup language

--- a/.github/workflows/build-typescript-project.yml
+++ b/.github/workflows/build-typescript-project.yml
@@ -43,13 +43,13 @@ jobs:
     steps:
       - name: 'Checkout project for pull_request_target trigger'
         if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 'Checkout project for other scenarios'
         if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 'Determine package manager'
         run: |
@@ -63,12 +63,12 @@ jobs:
 
       - if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
         name: 'Install pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
 
       - name: 'Install latest node version'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: ${{ env.PACKAGE_MANAGER }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: 'Upload artifact'
         if: ${{ inputs.artifactName }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifactName }}
           path: ${{ inputs.artifactPath }}

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -19,13 +19,13 @@ jobs:
     outputs:
       diff: ${{ steps.diff.outputs.diff }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
 

--- a/.github/workflows/check-template-consistency.yml
+++ b/.github/workflows/check-template-consistency.yml
@@ -17,7 +17,7 @@ jobs:
       has_diff: ${{ steps.diff.outputs.has_diff }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate code
         run: |

--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -28,7 +28,7 @@ jobs:
     name: Run tests & check coverage
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 'Determine package manager'
         run: |
@@ -42,12 +42,12 @@ jobs:
 
       - if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
         name: 'Install pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
 
       - name: 'Install latest node version'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: ${{ env.PACKAGE_MANAGER }}

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -31,7 +31,7 @@ jobs:
         if: inputs.prerelease == false
         run: exit 1
       - name: Checkout rc branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 'rc'
           persist-credentials: false
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 'main'
           persist-credentials: false

--- a/.github/workflows/docs-and-coverage.yml
+++ b/.github/workflows/docs-and-coverage.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 'Determine package manager'
         run: |
@@ -45,12 +45,12 @@ jobs:
 
       - if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
         name: 'Install pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
 
       - name: 'Install latest node version'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           check-latest: true

--- a/.github/workflows/move-v1-tag.yml
+++ b/.github/workflows/move-v1-tag.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check branch
         run: |

--- a/.github/workflows/preview-changeset-release.yml
+++ b/.github/workflows/preview-changeset-release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains('[changeset] ', inputs.pr-title) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: 'Determine package manager'
         run: |
@@ -41,12 +41,12 @@ jobs:
 
       - if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
         name: 'Install pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
 
       - name: 'Install latest node version'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: ${{ env.PACKAGE_MANAGER }}

--- a/.github/workflows/release-dx-packages.yml
+++ b/.github/workflows/release-dx-packages.yml
@@ -19,17 +19,17 @@ jobs:
     environment: production-npm
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: lts/*
           cache: pnpm
 
       # Ensure npm 11.5.1 or later is installed for trusted publishing

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -64,7 +64,7 @@ jobs:
       action: ${{ steps.changeset-determine-step.outputs.action }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 'Determine package manager'
         run: |
@@ -78,7 +78,7 @@ jobs:
 
       - if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
         name: 'Setup pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
           run_install: 'true'
@@ -106,7 +106,7 @@ jobs:
           private-key: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
 
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -124,7 +124,7 @@ jobs:
       # Setup PNPM for other projects than node to install changeset globally
       - name: 'Setup pnpm'
         if: ${{ inputs.language != 'node' }}
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
           run_install: 'true'
@@ -155,7 +155,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -173,7 +173,7 @@ jobs:
       # Setup PNPM for other projects than node to install changeset globally
       - name: 'Setup pnpm'
         if: ${{ inputs.language != 'node' }}
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
           run_install: 'true'

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -47,7 +47,7 @@ jobs:
     environment: production
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -68,7 +68,7 @@ jobs:
     environment: production
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -84,12 +84,12 @@ jobs:
 
       - if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
         name: 'Install pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
 
       - name: 'Install latest node version'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: ${{ env.PACKAGE_MANAGER }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: 'Download dist folder artifact'
         if: ${{ inputs.distFolderNeedForRelease }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-folder
           path: ${{ inputs.releaseWorkingDirectory != '' && format('{0}/dist', inputs.releaseWorkingDirectory) || './dist' }}

--- a/.github/workflows/reset-prerelease-branch.yml
+++ b/.github/workflows/reset-prerelease-branch.yml
@@ -31,7 +31,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/test-paths-changed.yml
+++ b/.github/workflows/test-paths-changed.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test paths-changed action
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # A PR always changes at least one file, so '**' must always match.
       - name: Run action with a matching pattern

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -108,7 +108,7 @@ jobs:
           owner: '${{ inputs.owner }}'
 
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: ${{ inputs.owner }}/${{ inputs.repository }}
@@ -121,13 +121,13 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: 'Setup pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
           run_install: true
 
       - name: 'Install Node'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.language == 'node' && inputs.language-version || 'lts/*' }}
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

- **`actions/checkout`**: `v4` -> `v7`
- **`actions/setup-node`**: `v4` -> `v6`
- **`pnpm/action-setup`**: `v3.0.0` -> `v6.0.9`
- **`actions/upload-artifact`**: `v4` -> `v7`
- **`actions/download-artifact`**: `v4` -> `v8`
- **`node-version: 20.x`** -> `lts/*`

## What changed and why

**`actions/checkout` (v4 -> v7):** Picks up Node 20 -> 24 runtime

**`actions/setup-node` (v4 -> v6):** Node 24 runtime; v5 added `node-version` resolution improvements, v6 adds corepack support.

**`pnpm/action-setup` (v3.0.0 -> v6.0.9):** Same bump already applied to `setup-lang/action.yml` in #159 .

**`actions/upload-artifact` (v4 -> v7) / `actions/download-artifact` (v4 -> v8):** v7/v8 use Node 24.

**`node-version: 20.x` -> `lts/*`** in `release-dx-packages.yml`: Hardcoded `20.x` would have kept CI pinned to a specific Node version. `lts/*` follows the active LTS release.