### PR TITLE
INTER-2221: Bump `marocchino/sticky-pull-request-comment` to `v3.0.4`

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -98,7 +98,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
         shell: bash
       - if: ${{ failure() && steps.commitlint.outcome == 'failure' }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: Commitlint
           recreate: true
@@ -118,7 +118,7 @@ jobs:
             ### Commitlint Errors
             ${{ steps.commitlint_formatted_results.outputs.formatted }}
       - if: ${{ success() }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: Commitlint
           hide: true
@@ -154,7 +154,7 @@ jobs:
           cwd: ${{ inputs.releaseWorkingDirectory }}
       - if: ${{ steps.semantic_release_info.outputs.no_release == 'false' }}
         name: Add comment to the PR
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: ReleasePreview
           recreate: true
@@ -164,7 +164,7 @@ jobs:
             ${{steps.semantic_release_info.outputs.notes}}
       - if: ${{ steps.semantic_release_info.outputs.no_release == 'true' }}
         name: Add comment to the PR
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: ReleasePreview
           recreate: true

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Add comment
         if: steps.diff.outputs.diff == '1'
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           message: |
             ⚠️ There were changes to GitHub actions. Don't forget to run:
@@ -57,7 +57,7 @@ jobs:
 
       - name: Remove comment
         if: steps.diff.outputs.diff != '1'
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           delete: true
 

--- a/.github/workflows/check-template-consistency.yml
+++ b/.github/workflows/check-template-consistency.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Add comment
         if: steps.diff.outputs.has_diff == '1'
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: 'template-consistency'
           message: |
@@ -60,7 +60,7 @@ jobs:
 
       - name: Remove comment
         if: steps.diff.outputs.has_diff != '1'
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: 'template-consistency'
           delete: true

--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -78,7 +78,7 @@ jobs:
           test-script: ${{ inputs.testScript }}
 
       - name: Add comment with coverage report
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           message: |
             ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/preview-changeset-release.yml
+++ b/.github/workflows/preview-changeset-release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: 'Add comment to PR'
         if: steps.notes.outputs.release-notes != ''
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: Release notes
           recreate: true
@@ -77,7 +77,7 @@ jobs:
 
       - name: 'Add comment to PR'
         if: steps.notes.outputs.release-notes == ''
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: Release notes
           recreate: true


### PR DESCRIPTION
## Summary

Bump `marocchino/sticky-pull-request-comment` from `v2.9.0` to `v3.0.4` in all workflow files.

## Why

`v2.9.0` uses `runs.using: node20` ([ref](https://github.com/marocchino/sticky-pull-request-comment/blob/331f8f5b4215f0445d3c07b4967662a32a2d3e31/action.yml#L91)), which GH has deprecated. This produced/shows a deprecation warning on every workflow.

## Compatibility

All `with:` inputs currently in use are unchanged in v3. v3 adds several new optional inputs. None required, no
effect on existing usage.