### PR TITLE
INTER-2221: Bump docs and changeset actions to latest

### DIFF
--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Jest coverage comment
         id: coverage
-        uses: ArtiomTr/jest-coverage-report-action@c026e98ae079f4b0b027252c8e957f5ebd420610
+        uses: ArtiomTr/jest-coverage-report-action@262a7bb0b20c4d1d6b6b026af0f008f78da72788 # v2.3.1
         with:
           package-manager: ${{ env.PACKAGE_MANAGER }}
           output: report-markdown

--- a/.github/workflows/docs-and-coverage.yml
+++ b/.github/workflows/docs-and-coverage.yml
@@ -74,7 +74,7 @@ jobs:
         run: $PACKAGE_MANAGER test:coverage
 
       - name: Create Coverage Badges
-        uses: jaywcjlove/coverage-badges-cli@df58615045079f1c827de7867044bbab3ec22b43
+        uses: jaywcjlove/coverage-badges-cli@998665f7962b1a3935ba8c3e786171a99436e5d1 # v2.3.0
         with:
           source: coverage/coverage-summary.json
           output: coverage/lcov-report/badges.svg
@@ -85,7 +85,7 @@ jobs:
           ${{ inputs.prepare-gh-pages-commands }}
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: gh-pages

--- a/.github/workflows/release-dx-packages.yml
+++ b/.github/workflows/release-dx-packages.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm test
 
       - name: Create Release
-        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm changeset publish
           commit: 'chore(release): changeset created a new release'

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -133,7 +133,7 @@ jobs:
         run: 'pnpm install @changesets/cli --global'
 
       - name: Create Release PR
-        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: ${{ inputs.version-command }}
           commit: 'chore(release): changeset created a new release'
@@ -192,7 +192,7 @@ jobs:
 
       - name: Create Release
         id: changesets-release
-        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: ${{ inputs.publish-command }}
           version: ${{ inputs.version-command }}


### PR DESCRIPTION
## Summary

Minor and patch bumps. All changes stay within the same major version.

| Action | From | To | Files |
|--------|------|----|-------|
| `JamesIves/github-pages-deploy-action` | `65b5dfd` (v4.5.0) | `d92aa23` (v4.8.0) | `docs-and-coverage.yml` |
| `jaywcjlove/coverage-badges-cli` | `df58615` (v2.0.0) | `998665f` (v2.3.0) | `docs-and-coverage.yml` |
| `ArtiomTr/jest-coverage-report-action` | `c026e98` (v2.3.0) | `262a7bb` (v2.3.1) | `coverage-diff.yml` |
| `changesets/action` | `c48e67d` (v1.6.0) | `a45c4d5` (v1.9.0) | `release-dx-packages.yml`, `release-sdk-changesets.yml` |

## Why

To pick up bug fixes and improvements within each action's current major. No input or output names changed across any of these bumps.