### PR TITLE
INTER-2221: Bump `actions/create-github-app-token` to `v3.2.0`

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -13,10 +13,14 @@ on:
       prerelease:
         required: false
         type: boolean
+      client_id:
+        type: string
+        required: false
+        description: 'GitHub App client ID for obtaining token.'
       app_id:
         type: string
         required: false
-        description: 'GitHub app id for obtaining token.'
+        description: 'Deprecated: use client_id instead. GitHub App client ID for obtaining token.'
     secrets:
       APP_PRIVATE_KEY:
         description: 'GitHub App token to request GitHub token.'
@@ -37,18 +41,18 @@ jobs:
           persist-credentials: false
 
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.app_id != '' }}
+        if: ${{ inputs.client_id != '' || inputs.app_id != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.client_id || inputs.app_id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request from tag branch to main
         run: |
           gh pr create --title "Release ${{ inputs.tag_name }}" --body "Release ${{ inputs.tag_name }}" --base main --head rc --repo ${{ github.repository }}
         env:
-          GITHUB_TOKEN: ${{ inputs.app_id != '' && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ (inputs.client_id != '' || inputs.app_id != '') && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
   create-pr-to-sync-with-main:
     if: inputs.target_branch != 'main'
@@ -61,15 +65,15 @@ jobs:
           persist-credentials: false
 
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.app_id != '' }}
+        if: ${{ inputs.client_id != '' || inputs.app_id != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.client_id || inputs.app_id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request from main to rc
         run: |
           gh pr create --title "Sync ${{ inputs.target_branch }} with main" --body "Sync ${{ inputs.target_branch }} with main" --base ${{ inputs.target_branch }} --head main --repo ${{ github.repository }}
         env:
-          GITHUB_TOKEN: ${{ inputs.app_id != '' && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ (inputs.client_id != '' || inputs.app_id != '') && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request from tag branch to main
@@ -65,7 +65,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request from main to rc

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -13,14 +13,14 @@ on:
       prerelease:
         required: false
         type: boolean
-      client_id:
+      client-id:
         type: string
         required: false
         description: 'GitHub App client ID for obtaining token.'
       app_id:
         type: string
         required: false
-        description: 'Deprecated: use client_id instead. GitHub App client ID for obtaining token.'
+        description: 'Deprecated: use client-id instead. GitHub App client ID for obtaining token.'
     secrets:
       APP_PRIVATE_KEY:
         description: 'GitHub App token to request GitHub token.'
@@ -41,18 +41,18 @@ jobs:
           persist-credentials: false
 
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.client_id != '' || inputs.app_id != '' }}
+        if: ${{ inputs.client-id != '' || inputs.app_id != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.client_id || inputs.app_id }}
+          client-id: ${{ inputs.client-id || inputs.app_id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request from tag branch to main
         run: |
           gh pr create --title "Release ${{ inputs.tag_name }}" --body "Release ${{ inputs.tag_name }}" --base main --head rc --repo ${{ github.repository }}
         env:
-          GITHUB_TOKEN: ${{ (inputs.client_id != '' || inputs.app_id != '') && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ (inputs.client-id != '' || inputs.app_id != '') && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
   create-pr-to-sync-with-main:
     if: inputs.target_branch != 'main'
@@ -65,15 +65,15 @@ jobs:
           persist-credentials: false
 
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.client_id != '' || inputs.app_id != '' }}
+        if: ${{ inputs.client-id != '' || inputs.app_id != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.client_id || inputs.app_id }}
+          client-id: ${{ inputs.client-id || inputs.app_id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request from main to rc
         run: |
           gh pr create --title "Sync ${{ inputs.target_branch }} with main" --body "Sync ${{ inputs.target_branch }} with main" --base ${{ inputs.target_branch }} --head main --repo ${{ github.repository }}
         env:
-          GITHUB_TOKEN: ${{ (inputs.client_id != '' || inputs.app_id != '') && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ (inputs.client-id != '' || inputs.app_id != '') && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.app_id != '' }}
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.app_id }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.app_id != '' }}
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.app_id }}

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -40,6 +40,12 @@ jobs:
           ref: 'rc'
           persist-credentials: false
 
+      - name: 'Validate app credentials'
+        if: ${{ (inputs.client-id != '' || inputs.app_id != '') && secrets.APP_PRIVATE_KEY == '' }}
+        run: |
+          echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or app_id is set"
+          exit 1
+
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.client-id != '' || inputs.app_id != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -63,6 +69,12 @@ jobs:
         with:
           ref: 'main'
           persist-credentials: false
+
+      - name: 'Validate app credentials'
+        if: ${{ (inputs.client-id != '' || inputs.app_id != '') && secrets.APP_PRIVATE_KEY == '' }}
+        run: |
+          echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or app_id is set"
+          exit 1
 
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.client-id != '' || inputs.app_id != '' }}

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -44,7 +44,7 @@ on:
         type: string
         default: ''
         required: false
-        description: 'GitHub App client ID for creating PR.'
+        description: 'GitHub App ID used to generate an installation token for creating the PR.'
       runnerAppId:
         type: string
         default: ''

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -32,15 +32,15 @@ on:
         required: false
         type: string
         default: '11'
-      clientId:
+      client-id:
         type: string
         required: false
         description: 'GitHub App client ID for release process.'
       appId:
         type: string
         required: false
-        description: 'Deprecated: use clientId instead. GitHub App client ID for release process.'
-      runnerClientId:
+        description: 'Deprecated: use client-id instead. GitHub App client ID for release process.'
+      runner-client-id:
         type: string
         default: ''
         required: false
@@ -49,7 +49,7 @@ on:
         type: string
         default: ''
         required: false
-        description: 'Deprecated: use runnerClientId instead. GitHub App client ID for creating PR.'
+        description: 'Deprecated: use runner-client-id instead. GitHub App client ID for creating PR.'
       useTrustedPublishing:
         type: boolean
         required: false
@@ -105,13 +105,13 @@ jobs:
   create-pr:
     runs-on: ubuntu-latest
     needs: determine-changesets-step
-    if: needs.determine-changesets-step.outputs.action == 'pr' && (inputs.runnerClientId != '' || inputs.runnerAppId != '')
+    if: needs.determine-changesets-step.outputs.action == 'pr' && (inputs.runner-client-id != '' || inputs.runnerAppId != '')
     steps:
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.runnerClientId || inputs.runnerAppId }}
+          client-id: ${{ inputs.runner-client-id || inputs.runnerAppId }}
           private-key: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
 
       - name: 'Checkout repository'
@@ -153,14 +153,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     needs: determine-changesets-step
-    if: needs.determine-changesets-step.outputs.action == 'publish' || (inputs.runnerClientId == '' && inputs.runnerAppId == '')
+    if: needs.determine-changesets-step.outputs.action == 'publish' || (inputs.runner-client-id == '' && inputs.runnerAppId == '')
     steps:
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.clientId != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.clientId || inputs.appId }}
+          client-id: ${{ inputs.client-id || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Checkout repository'

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.runnerAppId }}
+          client-id: ${{ inputs.runnerAppId }}
           private-key: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
 
       - name: 'Checkout repository'
@@ -151,7 +151,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Checkout repository'

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -99,7 +99,7 @@ jobs:
     if: needs.determine-changesets-step.outputs.action == 'pr' && inputs.runnerAppId != ''
     steps:
       - name: 'Get token for the GitHub App'
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.runnerAppId }}
@@ -148,7 +148,7 @@ jobs:
     steps:
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.appId != '' }}
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.appId }}

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -107,6 +107,12 @@ jobs:
     needs: determine-changesets-step
     if: needs.determine-changesets-step.outputs.action == 'pr' && (inputs.runner-client-id != '' || inputs.runnerAppId != '')
     steps:
+      - name: 'Validate runner app credentials'
+        if: ${{ secrets.RUNNER_APP_PRIVATE_KEY == '' }}
+        run: |
+          echo "Error: RUNNER_APP_PRIVATE_KEY secret must be provided when runner-client-id or runnerAppId is set"
+          exit 1
+
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -155,6 +161,12 @@ jobs:
     needs: determine-changesets-step
     if: needs.determine-changesets-step.outputs.action == 'publish' || (inputs.runner-client-id == '' && inputs.runnerAppId == '')
     steps:
+      - name: 'Validate app credentials'
+        if: ${{ inputs.client-id == '' && inputs.appId == '' }}
+        run: |
+          echo "Error: either 'client-id' or 'appId' (deprecated) must be provided"
+          exit 1
+
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -32,15 +32,24 @@ on:
         required: false
         type: string
         default: '11'
+      clientId:
+        type: string
+        required: false
+        description: 'GitHub App client ID for release process.'
       appId:
         type: string
-        required: true
-        description: 'GitHub app id for release process.'
+        required: false
+        description: 'Deprecated: use clientId instead. GitHub App client ID for release process.'
+      runnerClientId:
+        type: string
+        default: ''
+        required: false
+        description: 'GitHub App client ID for creating PR.'
       runnerAppId:
         type: string
         default: ''
         required: false
-        description: 'GitHub app id for creating PR.'
+        description: 'Deprecated: use runnerClientId instead. GitHub App client ID for creating PR.'
       useTrustedPublishing:
         type: boolean
         required: false
@@ -96,13 +105,13 @@ jobs:
   create-pr:
     runs-on: ubuntu-latest
     needs: determine-changesets-step
-    if: needs.determine-changesets-step.outputs.action == 'pr' && inputs.runnerAppId != ''
+    if: needs.determine-changesets-step.outputs.action == 'pr' && (inputs.runnerClientId != '' || inputs.runnerAppId != '')
     steps:
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.runnerAppId }}
+          client-id: ${{ inputs.runnerClientId || inputs.runnerAppId }}
           private-key: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
 
       - name: 'Checkout repository'
@@ -144,14 +153,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     needs: determine-changesets-step
-    if: needs.determine-changesets-step.outputs.action == 'publish' || inputs.runnerAppId == ''
+    if: needs.determine-changesets-step.outputs.action == 'publish' || (inputs.runnerClientId == '' && inputs.runnerAppId == '')
     steps:
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.appId != '' }}
+        if: ${{ inputs.clientId != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.clientId || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Checkout repository'

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.appId != '' }}
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.appId }}

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -23,14 +23,14 @@ on:
         description: 'Additional plugins to install for the semantic-release action.'
         required: false
         type: string
-      clientId:
+      client-id:
         type: string
         required: false
         description: 'GitHub App client ID for release process.'
       appId:
         type: string
         required: false
-        description: 'Deprecated: use clientId instead. GitHub App client ID for release process.'
+        description: 'Deprecated: use client-id instead. GitHub App client ID for release process.'
     secrets:
       GH_RELEASE_TOKEN:
         description: 'GitHub token with permissions to create releases and perform other necessary operations.'
@@ -67,11 +67,11 @@ jobs:
         run: ${{ inputs.prepare-command }}
 
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.clientId != '' || inputs.appId != '' }}
+        if: ${{ inputs.client-id != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.clientId || inputs.appId }}
+          client-id: ${{ inputs.client-id || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Semantic Release'
@@ -83,6 +83,6 @@ jobs:
             @fingerprintjs/conventional-changelog-dx-team@0.1.0
             ${{ inputs.semantic-release-extra-plugins }}
         env:
-          GITHUB_TOKEN: ${{ (inputs.clientId != '' || inputs.appId != '') && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ (inputs.client-id != '' || inputs.appId != '') && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Semantic Release'

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -23,10 +23,14 @@ on:
         description: 'Additional plugins to install for the semantic-release action.'
         required: false
         type: string
+      clientId:
+        type: string
+        required: false
+        description: 'GitHub App client ID for release process.'
       appId:
         type: string
         required: false
-        description: 'GitHub app id for release process.'
+        description: 'Deprecated: use clientId instead. GitHub App client ID for release process.'
     secrets:
       GH_RELEASE_TOKEN:
         description: 'GitHub token with permissions to create releases and perform other necessary operations.'
@@ -63,11 +67,11 @@ jobs:
         run: ${{ inputs.prepare-command }}
 
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.appId != '' }}
+        if: ${{ inputs.clientId != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.clientId || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Semantic Release'
@@ -79,6 +83,6 @@ jobs:
             @fingerprintjs/conventional-changelog-dx-team@0.1.0
             ${{ inputs.semantic-release-extra-plugins }}
         env:
-          GITHUB_TOKEN: ${{ inputs.appId != '' && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ (inputs.clientId != '' || inputs.appId != '') && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -66,6 +66,12 @@ jobs:
         if: ${{ inputs.prepare-command != '' }}
         run: ${{ inputs.prepare-command }}
 
+      - name: 'Validate app credentials'
+        if: ${{ (inputs.client-id != '' || inputs.appId != '') && secrets.APP_PRIVATE_KEY == '' }}
+        run: |
+          echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or appId is set"
+          exit 1
+
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.client-id != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.appId != '' }}
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.appId }}

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Semantic Release'

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -15,14 +15,14 @@ on:
         type: boolean
         required: false
         description: 'Flag that we need `dist` folder to start release process'
-      clientId:
+      client-id:
         type: string
         required: false
         description: 'GitHub App client ID for release process'
       appId:
         type: string
         required: false
-        description: 'Deprecated: use clientId instead. GitHub App client ID for release process'
+        description: 'Deprecated: use client-id instead. GitHub App client ID for release process'
       runsOn:
         type: string
         required: false
@@ -120,11 +120,11 @@ jobs:
         if: ${{ inputs.runAfterInstall != '' }}
 
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.clientId != '' || inputs.appId != '' }}
+        if: ${{ inputs.client-id != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.clientId || inputs.appId }}
+          client-id: ${{ inputs.client-id || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Semantic Release'
@@ -136,7 +136,7 @@ jobs:
             @semantic-release/exec@6.0.3
             conventional-changelog-conventionalcommits@5.0.0
         env:
-          GITHUB_TOKEN: ${{ (inputs.clientId != '' || inputs.appId != '') && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ (inputs.client-id != '' || inputs.appId != '') && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           HUSKY: 0
       

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -119,6 +119,12 @@ jobs:
         run: ${{ inputs.runAfterInstall }}
         if: ${{ inputs.runAfterInstall != '' }}
 
+      - name: 'Validate app credentials'
+        if: ${{ (inputs.client-id != '' || inputs.appId != '') && secrets.APP_PRIVATE_KEY == '' }}
+        run: |
+          echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or appId is set"
+          exit 1
+
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.client-id != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -15,10 +15,14 @@ on:
         type: boolean
         required: false
         description: 'Flag that we need `dist` folder to start release process'
+      clientId:
+        type: string
+        required: false
+        description: 'GitHub App client ID for release process'
       appId:
         type: string
         required: false
-        description: 'GitHub app id for release process'
+        description: 'Deprecated: use clientId instead. GitHub App client ID for release process'
       runsOn:
         type: string
         required: false
@@ -116,11 +120,11 @@ jobs:
         if: ${{ inputs.runAfterInstall != '' }}
 
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.appId != '' }}
+        if: ${{ inputs.clientId != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.clientId || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Semantic Release'
@@ -132,7 +136,7 @@ jobs:
             @semantic-release/exec@6.0.3
             conventional-changelog-conventionalcommits@5.0.0
         env:
-          GITHUB_TOKEN: ${{ inputs.appId != '' && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ (inputs.clientId != '' || inputs.appId != '') && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           HUSKY: 0
       

--- a/.github/workflows/reset-prerelease-branch.yml
+++ b/.github/workflows/reset-prerelease-branch.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/reset-prerelease-branch.yml
+++ b/.github/workflows/reset-prerelease-branch.yml
@@ -7,14 +7,14 @@ on:
         required: true
         type: string
         description: 'Branch to reset'
-      clientId:
+      client-id:
         type: string
         required: false
         description: 'GitHub App client ID for release process'
       appId:
         type: string
         required: false
-        description: 'Deprecated: use clientId instead. GitHub App client ID for release process'
+        description: 'Deprecated: use client-id instead. GitHub App client ID for release process'
     secrets:
       APP_PRIVATE_KEY:
         description: 'GitHub App token to request GitHub token'
@@ -27,11 +27,10 @@ jobs:
     environment: production
     steps:
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.clientId != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.clientId || inputs.appId }}
+          client-id: ${{ inputs.client-id || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/reset-prerelease-branch.yml
+++ b/.github/workflows/reset-prerelease-branch.yml
@@ -7,10 +7,14 @@ on:
         required: true
         type: string
         description: 'Branch to reset'
+      clientId:
+        type: string
+        required: false
+        description: 'GitHub App client ID for release process'
       appId:
         type: string
-        required: true
-        description: 'GitHub app id for release process'
+        required: false
+        description: 'Deprecated: use clientId instead. GitHub App client ID for release process'
     secrets:
       APP_PRIVATE_KEY:
         description: 'GitHub App token to request GitHub token'
@@ -23,11 +27,11 @@ jobs:
     environment: production
     steps:
       - name: 'Get token for the GitHub App'
-        if: ${{ inputs.appId != '' }}
+        if: ${{ inputs.clientId != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.clientId || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/reset-prerelease-branch.yml
+++ b/.github/workflows/reset-prerelease-branch.yml
@@ -26,6 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: 'Validate app credentials'
+        if: ${{ inputs.client-id == '' && inputs.appId == '' }}
+        run: |
+          echo "Error: either 'client-id' or 'appId' (deprecated) must be provided"
+          exit 1
+
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token

--- a/.github/workflows/reset-prerelease-branch.yml
+++ b/.github/workflows/reset-prerelease-branch.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.appId != '' }}
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.appId }}

--- a/.github/workflows/run-server-sdk-e2e-tests.yml
+++ b/.github/workflows/run-server-sdk-e2e-tests.yml
@@ -11,14 +11,14 @@ on:
         description: 'Type of SDK to test, can be: go, dotnet, node, php, python, java'
         type: string
         required: true
-      clientId:
+      client-id:
         type: string
         required: false
         description: 'GitHub App client ID to access the repository with E2E tests'
       appId:
         type: string
         required: false
-        description: 'Deprecated: use clientId instead. GitHub App client ID to access the repository with E2E tests'
+        description: 'Deprecated: use client-id instead. GitHub App client ID to access the repository with E2E tests'
       sdkPackageName:
         description: 'Custom package name for old SDK versions'
         required: false
@@ -38,11 +38,17 @@ jobs:
     name: 'E2E Tests'
     runs-on: ubuntu-latest
     steps:
+      - name: 'Validate app credentials'
+        if: ${{ inputs.client-id == '' && inputs.appId == '' }}
+        run: |
+          echo "Error: either 'client-id' or 'appId' (deprecated) must be provided"
+          exit 1
+
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.clientId || inputs.appId }}
+          client-id: ${{ inputs.client-id || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: fingerprintjs
           repositories: dx-team-orchestra

--- a/.github/workflows/run-server-sdk-e2e-tests.yml
+++ b/.github/workflows/run-server-sdk-e2e-tests.yml
@@ -11,10 +11,14 @@ on:
         description: 'Type of SDK to test, can be: go, dotnet, node, php, python, java'
         type: string
         required: true
+      clientId:
+        type: string
+        required: false
+        description: 'GitHub App client ID to access the repository with E2E tests'
       appId:
         type: string
-        required: true
-        description: 'GitHub app id to access the repository with E2E tests'
+        required: false
+        description: 'Deprecated: use clientId instead. GitHub App client ID to access the repository with E2E tests'
       sdkPackageName:
         description: 'Custom package name for old SDK versions'
         required: false
@@ -38,7 +42,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.clientId || inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: fingerprintjs
           repositories: dx-team-orchestra

--- a/.github/workflows/run-server-sdk-e2e-tests.yml
+++ b/.github/workflows/run-server-sdk-e2e-tests.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Get token for the GitHub App'
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.appId }}

--- a/.github/workflows/run-server-sdk-e2e-tests.yml
+++ b/.github/workflows/run-server-sdk-e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.appId }}
+          client-id: ${{ inputs.appId }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: fingerprintjs
           repositories: dx-team-orchestra

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Get token for the GitHub App'
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ inputs.app-id }}

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: '${{ inputs.repository }}'
           owner: '${{ inputs.owner }}'

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -40,10 +40,14 @@ on:
         description: 'Path to the OpenAPI examples.'
         required: true
         type: string
+      client-id:
+        type: string
+        required: false
+        description: 'GitHub App client ID for release process'
       app-id:
         type: string
-        required: true
-        description: 'GitHub app id for release process'
+        required: false
+        description: 'Deprecated: use client-id instead. GitHub App client ID for release process'
       repository:
         type: string
         required: true
@@ -102,7 +106,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.client-id || inputs.app-id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: '${{ inputs.repository }}'
           owner: '${{ inputs.owner }}'

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -102,6 +102,12 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: 'Validate app credentials'
+        if: ${{ inputs.client-id == '' && inputs.app-id == '' }}
+        run: |
+          echo "Error: either 'client-id' or 'app-id' (deprecated) must be provided"
+          exit 1
+
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token


### PR DESCRIPTION
## Summary

- Bump `actions/create-github-app-token` from `v1.9.0` to `v3.2.0` in all workflow files.
- Deprecate `app-id` -> `client-id` in all 3rd party action `with:` blocks (recommended name since v3)
- Introduce new `client-id` workflow input alongside the deprecated `app_id` input.
  - **Existing callers that still pass the old input names continue to work unchanged.**

## Compatibility

Inputs and outputs in use are all unchanged.

**v2.0.0 breaking change** (not applicable here): v2 removed the underscore-based inputs `app_id` and `private_key`. Our workflows already use the hyphenated form (`app-id`, `private-key`).

No new required inputs were added in v2 or v3.