### PR TITLE
INTER-2221: Bump semantic-release, commitlint, and dispatch tooling

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -85,7 +85,7 @@ jobs:
       - name: 'Install commit lint config'
         if: ${{ inputs.installSharedCommitLintConfig }}
         run: $PACKAGE_MANAGER add @fingerprintjs/commit-lint-dx-team@latest --ignore-workspace-root-check
-      - uses: wagoid/commitlint-github-action@5ce82f5d814d4010519d15f0552aec4f17a1e1fe
+      - uses: wagoid/commitlint-github-action@dbd4ecd47d0256b6587d1d0c5737082cc439f2c5 # v6.1.0
         id: commitlint
       - if: ${{ failure() && steps.commitlint.outcome == 'failure' }}
         name: 'Format commitlint results'

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -71,11 +71,11 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 'Semantic Release'
-        uses: cycjimmy/semantic-release-action@61680d0e9b02ff86f5648ade99e01be17f0260a4
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
           extra_plugins: |
-            @semantic-release/exec@6.0.3
-            conventional-changelog-conventionalcommits@5.0.0
+            @semantic-release/exec@7.1.0
+            conventional-changelog-conventionalcommits@9.3.1
             @fingerprintjs/conventional-changelog-dx-team@0.1.0
             ${{ inputs.semantic-release-extra-plugins }}
         env:

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -75,8 +75,7 @@ jobs:
         with:
           extra_plugins: |
             @semantic-release/exec@7.1.0
-            conventional-changelog-conventionalcommits@9.3.1
-            @fingerprintjs/conventional-changelog-dx-team@0.1.0
+            @fingerprintjs/conventional-changelog-dx-team@0.2.0
             ${{ inputs.semantic-release-extra-plugins }}
         env:
           GITHUB_TOKEN: ${{ inputs.appId != '' && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -125,12 +125,12 @@ jobs:
 
       - name: 'Semantic Release'
         id: release
-        uses: cycjimmy/semantic-release-action@61680d0e9b02ff86f5648ade99e01be17f0260a4
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
           working_directory: ${{ inputs.releaseWorkingDirectory }}
           extra_plugins: |
-            @semantic-release/exec@6.0.3
-            conventional-changelog-conventionalcommits@5.0.0
+            @semantic-release/exec@7.1.0
+            conventional-changelog-conventionalcommits@9.3.1
         env:
           GITHUB_TOKEN: ${{ inputs.appId != '' && steps.app-token.outputs.token || secrets.GH_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/run-server-sdk-e2e-tests.yml
+++ b/.github/workflows/run-server-sdk-e2e-tests.yml
@@ -43,7 +43,7 @@ jobs:
           owner: fingerprintjs
           repositories: dx-team-orchestra
 
-      - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0
+      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           repository: fingerprintjs/dx-team-orchestra
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -154,7 +154,7 @@ jobs:
           force: '${{ inputs.force }}'
 
       - name: Add & Commit
-        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           add: '.'
           github_token: ${{ steps.app-token.outputs.token }}
@@ -162,7 +162,7 @@ jobs:
           push: 'false'
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: 'OpenAPI schema sync (${{ inputs.tag }})'
           body: 'Schema sync for [${{ inputs.tag }}](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/releases/tag/${{ inputs.tag }}) OpenAPI schema release.'


### PR DESCRIPTION
## Summary

- **`cycjimmy/semantic-release-action`**: `61680d0` (v4.0.0) -> `b12c8f6` (v6.0.0)
  - Extra Plugins:
    - `@fingerprintjs/conventional-changelog-dx-team`** `@0.1.0` → `@0.2.0`
- **`wagoid/commitlint-github-action`** `5ce82f5` (v5.4.5) -> `dbd4ecd` (v6.1.0)
- **`peter-evans/repository-dispatch`** `ff45666` (v3.0.0) -> `28959ce` (v4.0.1)
- **`EndBug/add-and-commit`** `a94899b` (v9.1.4) -> `290ea2c` (v10.0.0)
- **`peter-evans/create-pull-request`** `c5a7806` (v6.1.0) -> `5f6978f` (v8.1.1)

## @fingerprintjs/conventional-changelog-dx-team: v0.1.0 → v0.2.0

`v0.2.0` converts the package to ESM and upgrades its `conventional-changelog-conventionalcommits` dependency from `^7.0.2` to `^9.0.0`. The explicit `conventional-changelog-conventionalcommits@9.3.1` pin in `extra_plugins` is removed. It now installs as a transitive dep of `@0.2.0`.
  
## Other actions
  
- **`cycjimmy/semantic-release-action` v4->v6**: upgrades bundled semantic-release to v25, Node 20 -> Node 24 runtime (**eliminates deprecation warning**).
- **`@semantic-release/exec` v6->v7**: v6 is technically compatible with semantic-release v25 (`peerDeps: >=18`), but v7 explicitly targets `>=24.1.0`. Input API unchanged.
- **`wagoid/commitlint-github-action` v5->v6**: Node 24 runtime; `configFile` input unchanged.
- **`peter-evans/repository-dispatch` v3->v4**: event payload interface unchanged.
- **`EndBug/add-and-commit` v9->v10**: same input API.
- **`peter-evans/create-pull-request` v6->v8**: input API unchanged, and we don't use its outputs.