### PR TITLE
[conventional-changelog-dx-team] Convert to ESM and update dependency

### DIFF
--- a/.changeset/conventional-changelog-dx-team-esm.md
+++ b/.changeset/conventional-changelog-dx-team-esm.md
@@ -6,6 +6,6 @@ Convert to ESM and upgrade `conventional-changelog-conventionalcommits` dependen
 
 `conventional-changelog-conventionalcommits` v8+ is ESM-only with an async `createPreset` API. The package now uses `import` instead of `require` and exports a default function (instead of exporting the preset config object directly) to match the async preset interface expected by semantic-release v24+.
 
-This preset now requires Node.js >=22.
+This preset now requires Node.js >=20.
 
 The changelog sections and commit-type-to-semver mappings are unchanged.

--- a/.changeset/conventional-changelog-dx-team-esm.md
+++ b/.changeset/conventional-changelog-dx-team-esm.md
@@ -6,6 +6,6 @@ Convert to ESM and upgrade `conventional-changelog-conventionalcommits` dependen
 
 `conventional-changelog-conventionalcommits` v8+ is ESM-only with an async `createPreset` API. The package now uses `import` instead of `require` and exports a default function (instead of exporting the preset config object directly) to match the async preset interface expected by semantic-release v24+.
 
-This preset now requires Node.js >=18.
+This preset now requires Node.js >=22.
 
 The changelog sections and commit-type-to-semver mappings are unchanged.

--- a/.changeset/conventional-changelog-dx-team-esm.md
+++ b/.changeset/conventional-changelog-dx-team-esm.md
@@ -1,0 +1,9 @@
+---
+"@fingerprintjs/conventional-changelog-dx-team": minor
+---
+
+Convert to ESM and upgrade `conventional-changelog-conventionalcommits` dependency from `^7.0.2` to `^9.0.0`.
+
+`conventional-changelog-conventionalcommits` v8+ is ESM-only with an async `createPreset` API. The package now uses `import` instead of `require` and exports a default function (instead of exporting the preset config object directly) to match the async preset interface expected by semantic-release v24+.
+
+The changelog sections and commit-type-to-semver mappings are unchanged.

--- a/.changeset/conventional-changelog-dx-team-esm.md
+++ b/.changeset/conventional-changelog-dx-team-esm.md
@@ -6,4 +6,6 @@ Convert to ESM and upgrade `conventional-changelog-conventionalcommits` dependen
 
 `conventional-changelog-conventionalcommits` v8+ is ESM-only with an async `createPreset` API. The package now uses `import` instead of `require` and exports a default function (instead of exporting the preset config object directly) to match the async preset interface expected by semantic-release v24+.
 
+This preset now requires Node.js >=18.
+
 The changelog sections and commit-type-to-semver mappings are unchanged.

--- a/packages/conventional-changelog-dx-team/index.js
+++ b/packages/conventional-changelog-dx-team/index.js
@@ -1,21 +1,21 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-const createPreset = require('conventional-changelog-conventionalcommits')
+import createPreset from 'conventional-changelog-conventionalcommits'
 
-module.exports = createPreset({
-  types: [
-    { type: 'feat', section: 'Features' },
-    { type: 'feature', section: 'Features' },
-    { type: 'fix', section: 'Bug Fixes' },
-    { type: 'perf', section: 'Performance Improvements' },
-    { type: 'revert', section: 'Reverts' },
-    { type: 'docs', scope: 'README', section: 'Documentation' },
-    { type: 'build', scope: 'deps', section: 'Build System' },
-    { type: 'docs', section: 'Documentation', hidden: true },
-    { type: 'style', section: 'Styles', hidden: true },
-    { type: 'chore', section: 'Miscellaneous Chores', hidden: true },
-    { type: 'refactor', section: 'Code Refactoring', hidden: true },
-    { type: 'test', section: 'Tests', hidden: true },
-    { type: 'build', section: 'Build System', hidden: true },
-    { type: 'ci', section: 'Continuous Integration', hidden: true },
-  ],
-})
+export default () =>
+  createPreset({
+    types: [
+      { type: 'feat', section: 'Features' },
+      { type: 'feature', section: 'Features' },
+      { type: 'fix', section: 'Bug Fixes' },
+      { type: 'perf', section: 'Performance Improvements' },
+      { type: 'revert', section: 'Reverts' },
+      { type: 'docs', scope: 'README', section: 'Documentation' },
+      { type: 'build', scope: 'deps', section: 'Build System' },
+      { type: 'docs', section: 'Documentation', hidden: true },
+      { type: 'style', section: 'Styles', hidden: true },
+      { type: 'chore', section: 'Miscellaneous Chores', hidden: true },
+      { type: 'refactor', section: 'Code Refactoring', hidden: true },
+      { type: 'test', section: 'Tests', hidden: true },
+      { type: 'build', section: 'Build System', hidden: true },
+      { type: 'ci', section: 'Continuous Integration', hidden: true },
+    ],
+  })

--- a/packages/conventional-changelog-dx-team/package.json
+++ b/packages/conventional-changelog-dx-team/package.json
@@ -14,6 +14,10 @@
     "provenance": true
   },
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./release-rules": "./release-rules.js"
+  },
   "files": [
     "index.js",
     "release-rules.js"

--- a/packages/conventional-changelog-dx-team/package.json
+++ b/packages/conventional-changelog-dx-team/package.json
@@ -19,6 +19,9 @@
     "release-rules.js"
   ],
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "conventional-changelog-conventionalcommits": "^9.0.0"
   }

--- a/packages/conventional-changelog-dx-team/package.json
+++ b/packages/conventional-changelog-dx-team/package.json
@@ -20,7 +20,7 @@
   ],
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "dependencies": {
     "conventional-changelog-conventionalcommits": "^9.0.0"

--- a/packages/conventional-changelog-dx-team/package.json
+++ b/packages/conventional-changelog-dx-team/package.json
@@ -18,7 +18,8 @@
     "index.js",
     "release-rules.js"
   ],
+  "type": "module",
   "dependencies": {
-    "conventional-changelog-conventionalcommits": "^7.0.2"
+    "conventional-changelog-conventionalcommits": "^9.0.0"
   }
 }

--- a/packages/conventional-changelog-dx-team/release-rules.js
+++ b/packages/conventional-changelog-dx-team/release-rules.js
@@ -11,4 +11,4 @@ const releaseRules = [
   { type: 'docs', scope: 'README', release: 'patch' },
 ]
 
-module.exports = releaseRules
+export default releaseRules

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
   packages/conventional-changelog-dx-team:
     dependencies:
       conventional-changelog-conventionalcommits:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^9.0.0
+        version: 9.3.1
 
   packages/eslint-config-dx-team:
     dependencies:
@@ -1440,9 +1440,9 @@ packages:
     resolution: {integrity: sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==}
     engines: {node: '>=14'}
 
-  conventional-changelog-conventionalcommits@7.0.2:
-    resolution: {integrity: sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==}
-    engines: {node: '>=16'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-commits-parser@4.0.0:
     resolution: {integrity: sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==}
@@ -4914,7 +4914,7 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@7.0.2:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
## Summary

- Convert `@fingerprintjs/conventional-changelog-dx-team` from CJS to ESM
- Upgrade `conventional-changelog-conventionalcommits` dependency from `^7.0.2` to `^9.0.0`
- All changelog sections and semver mappings are <ins>**unchanged**</ins>

## Why ESM?

`conventional-changelog-conventionalcommits` v8+ is ESM-only and exposes an async `createPreset` API. The old CJS `require()` + sync usage no longer works against v8+.

## Consumer compatibility

Every consumer references it as a string preset name in `.releaserc` (e.g. `"preset": "@fingerprintjs/conventional-changelog-dx-team"`). Semantic-release v24+ resolves preset strings via dynamic `import()`, which is fully compatible with ESM packages. No consumer `require()`s the package directly in JS code. **No consumer changes required.**
