### PR TITLE
[setup-lang] Install `uv` when running for python

### DIFF
--- a/.github/actions/setup-lang/action.yml
+++ b/.github/actions/setup-lang/action.yml
@@ -37,6 +37,10 @@ runs:
       with:
         python-version: ${{ inputs.language-version }}
 
+    - name: 'Install uv'
+      if: ${{ inputs.language == 'python' }}
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
     - name: 'Install Golang'
       if: ${{ inputs.language == 'golang' }}
       uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary

- Install `uv` with `astral-sh/setup-uv` action for Python projects in the `setup-lang` action

> [!NOTE]                                                                                                                                                                                                
> `uv` is installed **unconditionally** for all Python projects without an opt-in input or `uv.lock` check. `setup-uv` is fast and harmless if unused, and any Python SDK adopting `uv` would need it. Adding an input just creates one more thing every caller has to remember to set.