### PR TITLE
chore: remove app credentials validation steps in workflows

### DIFF
--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -107,12 +107,6 @@ jobs:
     needs: determine-changesets-step
     if: needs.determine-changesets-step.outputs.action == 'pr' && (inputs.runner-client-id != '' || inputs.runnerAppId != '')
     steps:
-      - name: 'Validate runner app credentials'
-        if: ${{ secrets.RUNNER_APP_PRIVATE_KEY == '' }}
-        run: |
-          echo "Error: RUNNER_APP_PRIVATE_KEY secret must be provided when runner-client-id or runnerAppId is set"
-          exit 1
-
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -119,12 +119,6 @@ jobs:
         run: ${{ inputs.runAfterInstall }}
         if: ${{ inputs.runAfterInstall != '' }}
 
-      - name: 'Validate app credentials'
-        if: ${{ (inputs.client-id != '' || inputs.appId != '') && secrets.APP_PRIVATE_KEY == '' }}
-        run: |
-          echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or appId is set"
-          exit 1
-
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.client-id != '' || inputs.appId != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
This PR removes validation of secret credential in shared workflows. Should fix broken release pipeline such as: https://github.com/fingerprintjs/dotnet-sdk/actions/runs/28580893106