### PR TITLE
[release-sdk-changesets] Fix secrets context usage

### DIFF
--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -108,10 +108,13 @@ jobs:
     if: needs.determine-changesets-step.outputs.action == 'pr' && (inputs.runner-client-id != '' || inputs.runnerAppId != '')
     steps:
       - name: 'Validate runner app credentials'
-        if: ${{ secrets.RUNNER_APP_PRIVATE_KEY == '' }}
+        env:
+          RUNNER_APP_PRIVATE_KEY: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
         run: |
-          echo "Error: RUNNER_APP_PRIVATE_KEY secret must be provided when runner-client-id or runnerAppId is set"
-          exit 1
+          if [ -z "$RUNNER_APP_PRIVATE_KEY" ]; then
+            echo "Error: RUNNER_APP_PRIVATE_KEY secret must be provided when runner-client-id or runnerAppId is set"
+            exit 1
+          fi
 
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
## Summary

- Fix workflow parse error caused by using `secrets` context in a step-level `if` condition, which is not supported in reusable workflows
- Move the `RUNNER_APP_PRIVATE_KEY` validation into the `run` block, passing the secret through `env:` where the `secrets` context is allowed

This caused all downstream SDK repos using `release-sdk-changesets.yml` to fail with:

> Unrecognized named-value: 'secrets'. Located at position 1 within expression:
> secrets.RUNNER_APP_PRIVATE_KEY == ''