### PR TITLE
INTER-2288: Fix secrets context usage for create-pr and release-typescript-project reusable workflows

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -41,10 +41,14 @@ jobs:
           persist-credentials: false
 
       - name: 'Validate app credentials'
-        if: ${{ (inputs.client-id != '' || inputs.app_id != '') && secrets.APP_PRIVATE_KEY == '' }}
+        if: ${{ inputs.client-id != '' || inputs.app_id != '' }}
+        env:
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
         run: |
-          echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or app_id is set"
-          exit 1
+          if [ -z "$APP_PRIVATE_KEY" ]; then
+            echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or app_id is set"
+            exit 1
+          fi
 
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.client-id != '' || inputs.app_id != '' }}
@@ -71,10 +75,14 @@ jobs:
           persist-credentials: false
 
       - name: 'Validate app credentials'
-        if: ${{ (inputs.client-id != '' || inputs.app_id != '') && secrets.APP_PRIVATE_KEY == '' }}
+        if: ${{ inputs.client-id != '' || inputs.app_id != '' }}
+        env:
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
         run: |
-          echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or app_id is set"
-          exit 1
+          if [ -z "$APP_PRIVATE_KEY" ]; then
+            echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or app_id is set"
+            exit 1
+          fi
 
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.client-id != '' || inputs.app_id != '' }}

--- a/.github/workflows/release-typescript-project.yml
+++ b/.github/workflows/release-typescript-project.yml
@@ -118,10 +118,14 @@ jobs:
         if: ${{ inputs.runAfterInstall != '' }}
 
       - name: 'Validate app credentials'
-        if: ${{ (inputs.client-id != '' || inputs.appId != '') && secrets.APP_PRIVATE_KEY == '' }}
+        if: ${{ inputs.client-id != '' || inputs.appId != '' }}
+        env:
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
         run: |
-          echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or appId is set"
-          exit 1
+          if [ -z "$APP_PRIVATE_KEY" ]; then
+            echo "Error: APP_PRIVATE_KEY secret must be provided when client-id or appId is set"
+            exit 1
+          fi
 
       - name: 'Get token for the GitHub App'
         if: ${{ inputs.client-id != '' || inputs.appId != '' }}


### PR DESCRIPTION
Did this fix in 2 other workflows and those were confirmed to be working after the fix was made. More context here: https://github.com/fingerprintjs/dx-team-toolkit/pull/175