### PR TITLE
fix(tests): strip devEngines from temp package so changeset tests pass in CI

### DIFF
--- a/__tests__/test-utils/changeset.ts
+++ b/__tests__/test-utils/changeset.ts
@@ -23,7 +23,15 @@ export function initTestPackage(withChangelogPreset = true) {
     fs.writeFileSync(changesetConfigPath, JSON.stringify(changesetConfig, null, 2))
   }
 
-  const testPkgJson: PackageJSON = JSON.parse(fs.readFileSync(path.join(testPkg.path, 'package.json'), 'utf-8'))
+  const testPkgJson: PackageJSON & { devEngines?: unknown; packageManager?: unknown } = JSON.parse(
+    fs.readFileSync(path.join(testPkg.path, 'package.json'), 'utf-8')
+  )
+
+  // Recent pnpm `init` writes a `devEngines.packageManager` block which makes the
+  // subsequent `pnpm install` crash with "Cannot use 'in' operator to search for
+  // 'integrity' in undefined". Strip it so the temp package installs cleanly.
+  delete testPkgJson.devEngines
+  delete testPkgJson.packageManager
 
   testPkgJson.dependencies = {
     '@changesets/cli': pkg.devDependencies['@changesets/cli'],

--- a/__tests__/test-utils/changeset.ts
+++ b/__tests__/test-utils/changeset.ts
@@ -27,9 +27,10 @@ export function initTestPackage(withChangelogPreset = true) {
     fs.readFileSync(path.join(testPkg.path, 'package.json'), 'utf-8')
   )
 
-  // Recent pnpm `init` writes a `devEngines.packageManager` block which makes the
-  // subsequent `pnpm install` crash with "Cannot use 'in' operator to search for
-  // 'integrity' in undefined". Strip it so the temp package installs cleanly.
+  // `pnpm init` may add package-manager metadata (`devEngines` / `packageManager`)
+  // whose exact shape depends on the pnpm version that generated it. We want this
+  // temp fixture to install predictably with whatever pnpm runs the tests, so drop
+  // that metadata and let the ambient package manager resolve dependencies as-is.
   delete testPkgJson.devEngines
   delete testPkgJson.packageManager
 


### PR DESCRIPTION
Jira: [INTER-2305](https://fingerprintjs.atlassian.net/browse/INTER-2305)

- Strip pnpm-generated `devEngines` / `packageManager` metadata from the temp fixture package in [`initTestPackage`](https://github.com/fingerprintjs/dx-team-toolkit/blob/fix/changeset-tests-devengines/__tests__/test-utils/changeset.ts#L26-L40) before running `pnpm install`.

Fixes the changeset-based test suites, which broke the [`Release` workflow](https://github.com/fingerprintjs/dx-team-toolkit/actions/runs/29238619198/job/86779080490) with no relevant code change.

### Why it broke

`pnpm init` now writes a `devEngines.packageManager` block into the generated `package.json`, and the following `pnpm install` chokes on it (`Cannot use 'in' operator to search for 'integrity' in undefined`). The block's shape depends on the pnpm version, which changed under us via a GitHub runner-image update — so this is environmental, not caused by the merged code. Stripping the metadata makes the fixture install predictably with whatever pnpm runs the tests.

### Verification

Confirmed in CI on a throwaway branch: the nested `pnpm install` crashes with the block present and succeeds once it's removed.

[INTER-2305]: https://fingerprintjs.atlassian.net/browse/INTER-2305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ