### PR TITLE
ci: bump changeset actions from node20 to node24 runtime

### DIFF
--- a/.github/actions/changeset-determine-step/action.yml
+++ b/.github/actions/changeset-determine-step/action.yml
@@ -5,5 +5,5 @@ outputs:
     description: 'Which action should be performed based on changesets (`pr` | `publish` | `none`)'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/actions/changeset-release-notes/action.yml
+++ b/.github/actions/changeset-release-notes/action.yml
@@ -5,5 +5,5 @@ outputs:
     description: 'Release notes'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
- Bump `changeset-determine-step` and `changeset-release-notes` JS actions from the `node20` to the `node24` runtime.
- Only the `runs.using` field changes — bundled `dist/` is untouched, so `check-dist` stays green and no rebuild is needed.

Clears the [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) that these two actions emit on every run of the ~10 reusable workflows that use them (`release-sdk-changesets`, `analyze-commits`, `build-typescript-project`, `coverage-diff`, `docs-and-coverage`, …), across all consuming SDK repos. `update-sdk-schema` already runs on `node24`. Surfaced while reviewing CI in `fingerprintjs/node-sdk`.

### No changeset needed

These actions ship via the `@v1` git tag, not npm — the changeset-bot warning is a false positive here.

### Follow-up: move the `v1` tag

The fix only reaches consumers once `v1` is moved to the merge commit (per the [release step in CONTRIBUTING](https://github.com/fingerprintjs/dx-team-toolkit/blob/main/CONTRIBUTING.md)).