### PR TITLE
Introduce coverage generation skip input

### DIFF
--- a/.github/workflows/docs-and-coverage.yml
+++ b/.github/workflows/docs-and-coverage.yml
@@ -11,20 +11,16 @@ on:
         type: string
         required: false
         description: Commands to run after installing dependencies.
-      prepare-gh-pages-commands:
-        required: false
-        default: |
-          mv docs ./gh-pages
-          mv coverage/lcov-report ./gh-pages/coverage
-        type: string
-        description: >
-          Commands to prepare the content of the gh-pages folder. The gh-pages folder will be created automatically.
-          Only specify the commands for moving files into it.
       skip-docs-step:
         required: false
         default: false
         type: boolean
         description: 'Skip the documentation generation step.'
+      skip-coverage-step:
+        required: false
+        default: false
+        type: boolean
+        description: 'Skip the coverage report generation step.'
 
 jobs:
   generate-docs-and-coverage:
@@ -69,18 +65,26 @@ jobs:
         run: $PACKAGE_MANAGER run docs
 
       - name: Collect coverage report
+        if: ${{ inputs.skip-coverage-step != true }}
         run: $PACKAGE_MANAGER test:coverage
 
       - name: Create Coverage Badges
+        if: ${{ inputs.skip-coverage-step != true }}
         uses: jaywcjlove/coverage-badges-cli@998665f7962b1a3935ba8c3e786171a99436e5d1 # v2.3.0
         with:
           source: coverage/coverage-summary.json
           output: coverage/lcov-report/badges.svg
 
-      - name: Prepare folder for gh-pages
-        run: |
-          mkdir gh-pages
-          ${{ inputs.prepare-gh-pages-commands }}
+      - name: Prepare gh-pages folder
+        run: mkdir gh-pages
+
+      - name: Move docs to the gh-pages folder
+        if: ${{ inputs.skip-docs-step != true }}
+        run: mv docs ./gh-pages
+
+      - name: Move coverage report to the gh-pages folder
+        if: ${{ inputs.skip-coverage-step != true }}
+        run: mv coverage/lcov-report ./gh-pages/coverage
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0


### PR DESCRIPTION
This pull request updates the `.github/workflows/docs-and-coverage.yml` workflow to improve flexibility and clarity in generating and deploying documentation and coverage reports. The main changes simplify the process for preparing the `gh-pages` folder and add new options for skipping specific steps.

**Workflow improvements:**

* Removed the `prepare-gh-pages-commands` input and replaced it with explicit steps for moving documentation and coverage reports into the `gh-pages` folder, making the workflow easier to understand and maintain. [[1]](diffhunk://#diff-7e5d784198d66a2fb5745c3b8c331bde89c70b7a40a201dec70f6e7e17f3f8e7L14-R23) [[2]](diffhunk://#diff-7e5d784198d66a2fb5745c3b8c331bde89c70b7a40a201dec70f6e7e17f3f8e7R68-R87)
* Added a new `skip-coverage-step` input to allow skipping the coverage report generation and related steps. [[1]](diffhunk://#diff-7e5d784198d66a2fb5745c3b8c331bde89c70b7a40a201dec70f6e7e17f3f8e7L14-R23) [[2]](diffhunk://#diff-7e5d784198d66a2fb5745c3b8c331bde89c70b7a40a201dec70f6e7e17f3f8e7R68-R87)
* Updated workflow steps to conditionally run documentation and coverage tasks based on the new and existing skip inputs (`skip-docs-step` and `skip-coverage-step`).