### PR TITLE
INTER-2225: Replace remote self-refs with local action checkout

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -145,6 +145,10 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        if: ${{ inputs.setupLanguage && inputs.setupLanguageVersion }}
+        run: echo '_dx-toolkit/' >> .git/info/exclude
+
       - name: Setup language
         if: ${{ inputs.setupLanguage && inputs.setupLanguageVersion }}
         uses: ./_dx-toolkit/.github/actions/setup-lang

--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -143,6 +143,7 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
       - name: Setup language
         if: ${{ inputs.setupLanguage && inputs.setupLanguageVersion }}

--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -135,9 +135,18 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.nodeVersion }}
+      - name: 'Checkout dx-team-toolkit actions'
+        if: ${{ inputs.setupLanguage && inputs.setupLanguageVersion }}
+        uses: actions/checkout@v7
+        with:
+          repository: fingerprintjs/dx-team-toolkit
+          ref: ${{ github.workflow_sha }}
+          path: _dx-toolkit
+          sparse-checkout: .github/actions
+
       - name: Setup language
         if: ${{ inputs.setupLanguage && inputs.setupLanguageVersion }}
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
           language: ${{ inputs.setupLanguage }}
           language-version: ${{ inputs.setupLanguageVersion }}

--- a/.github/workflows/preview-changeset-release.yml
+++ b/.github/workflows/preview-changeset-release.yml
@@ -56,9 +56,17 @@ jobs:
         if: ${{ inputs.prepare-command }}
         run: ${{ inputs.prepare-command }}
 
+      - name: 'Checkout dx-team-toolkit actions'
+        uses: actions/checkout@v7
+        with:
+          repository: fingerprintjs/dx-team-toolkit
+          ref: ${{ github.workflow_sha }}
+          path: _dx-toolkit
+          sparse-checkout: .github/actions
+
       - name: 'Get release notes'
         id: notes
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/changeset-release-notes@v1
+        uses: ./_dx-toolkit/.github/actions/changeset-release-notes
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/preview-changeset-release.yml
+++ b/.github/workflows/preview-changeset-release.yml
@@ -65,6 +65,9 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
+
       - name: 'Get release notes'
         id: notes
         uses: ./_dx-toolkit/.github/actions/changeset-release-notes

--- a/.github/workflows/preview-changeset-release.yml
+++ b/.github/workflows/preview-changeset-release.yml
@@ -63,6 +63,7 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
       - name: 'Get release notes'
         id: notes

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -107,6 +107,9 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
+
       - name: Determine changesets step
         id: changeset-determine-step
         uses: ./_dx-toolkit/.github/actions/changeset-determine-step
@@ -145,15 +148,15 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
+
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
-
-      - name: 'Exclude dx-team-toolkit checkout from git'
-        run: echo '_dx-toolkit/' >> .git/info/exclude
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}
@@ -210,15 +213,15 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
+
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
-
-      - name: 'Exclude dx-team-toolkit checkout from git'
-        run: echo '_dx-toolkit/' >> .git/info/exclude
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -105,6 +105,7 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
       - name: Determine changesets step
         id: changeset-determine-step
@@ -142,6 +143,7 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
@@ -150,8 +152,8 @@ jobs:
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
 
-      - name: 'Clean up dx-team-toolkit checkout'
-        run: rm -rf _dx-toolkit
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}
@@ -206,6 +208,7 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
@@ -214,8 +217,8 @@ jobs:
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
 
-      - name: 'Clean up dx-team-toolkit checkout'
-        run: rm -rf _dx-toolkit
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -98,9 +98,17 @@ jobs:
       - name: 'Install changesets'
         run: 'npm install @changesets/cli --global'
 
+      - name: 'Checkout dx-team-toolkit actions'
+        uses: actions/checkout@v7
+        with:
+          repository: fingerprintjs/dx-team-toolkit
+          ref: ${{ github.workflow_sha }}
+          path: _dx-toolkit
+          sparse-checkout: .github/actions
+
       - name: Determine changesets step
         id: changeset-determine-step
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/changeset-determine-step@v1
+        uses: ./_dx-toolkit/.github/actions/changeset-determine-step
   create-pr:
     runs-on: ubuntu-latest
     needs: determine-changesets-step
@@ -127,12 +135,23 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: 'Checkout dx-team-toolkit actions'
+        uses: actions/checkout@v7
+        with:
+          repository: fingerprintjs/dx-team-toolkit
+          ref: ${{ github.workflow_sha }}
+          path: _dx-toolkit
+          sparse-checkout: .github/actions
+
       - name: Setup language
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
+
+      - name: 'Clean up dx-team-toolkit checkout'
+        run: rm -rf _dx-toolkit
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}
@@ -180,12 +199,23 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: 'Checkout dx-team-toolkit actions'
+        uses: actions/checkout@v7
+        with:
+          repository: fingerprintjs/dx-team-toolkit
+          ref: ${{ github.workflow_sha }}
+          path: _dx-toolkit
+          sparse-checkout: .github/actions
+
       - name: Setup language
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
+
+      - name: 'Clean up dx-team-toolkit checkout'
+        run: rm -rf _dx-toolkit
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -62,6 +62,7 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
@@ -70,8 +71,8 @@ jobs:
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
 
-      - name: 'Clean up dx-team-toolkit checkout'
-        run: rm -rf _dx-toolkit
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -64,15 +64,15 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
+
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
-
-      - name: 'Exclude dx-team-toolkit checkout from git'
-        run: echo '_dx-toolkit/' >> .git/info/exclude
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -55,12 +55,23 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 'Checkout dx-team-toolkit actions'
+        uses: actions/checkout@v7
+        with:
+          repository: fingerprintjs/dx-team-toolkit
+          ref: ${{ github.workflow_sha }}
+          path: _dx-toolkit
+          sparse-checkout: .github/actions
+
       - name: Setup language
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
           java-version: ${{ inputs.java-version }}
+
+      - name: 'Clean up dx-team-toolkit checkout'
+        run: rm -rf _dx-toolkit
 
       - name: 'Prepare project'
         if: ${{ inputs.prepare-command != '' }}

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -123,8 +123,16 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           repository: ${{ inputs.owner }}/${{ inputs.repository }}
 
+      - name: 'Checkout dx-team-toolkit actions'
+        uses: actions/checkout@v7
+        with:
+          repository: fingerprintjs/dx-team-toolkit
+          ref: ${{ github.workflow_sha }}
+          path: _dx-toolkit
+          sparse-checkout: .github/actions
+
       - name: Setup language
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/setup-lang@v1
+        uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
           language: ${{ inputs.language }}
           language-version: ${{ inputs.language-version }}
@@ -146,7 +154,7 @@ jobs:
           git config --global --add --bool push.autoSetupRemote true
 
       - name: Update schema
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/update-sdk-schema@v1
+        uses: ./_dx-toolkit/.github/actions/update-sdk-schema
         with:
           schemaSource: ${{ inputs.schema-source }}
           schemaPath: ${{ inputs.schema-path }}
@@ -161,6 +169,9 @@ jobs:
           scopesRef: ${{ inputs.scopes-ref }}
           preReleaseTag: '${{ inputs.pre-release-tag }}'
           force: '${{ inputs.force }}'
+
+      - name: 'Clean up dx-team-toolkit checkout'
+        run: rm -rf _dx-toolkit
 
       - name: Add & Commit
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -132,6 +132,9 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
+
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
         with:
@@ -170,9 +173,6 @@ jobs:
           scopesRef: ${{ inputs.scopes-ref }}
           preReleaseTag: '${{ inputs.pre-release-tag }}'
           force: '${{ inputs.force }}'
-
-      - name: 'Exclude dx-team-toolkit checkout from git'
-        run: echo '_dx-toolkit/' >> .git/info/exclude
 
       - name: Add & Commit
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -130,6 +130,7 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
@@ -170,8 +171,8 @@ jobs:
           preReleaseTag: '${{ inputs.pre-release-tag }}'
           force: '${{ inputs.force }}'
 
-      - name: 'Clean up dx-team-toolkit checkout'
-        run: rm -rf _dx-toolkit
+      - name: 'Exclude dx-team-toolkit checkout from git'
+        run: echo '_dx-toolkit/' >> .git/info/exclude
 
       - name: Add & Commit
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0


### PR DESCRIPTION
## Summary

- Reusable workflows referenced their own composite actions using remote paths pinned to `@v1`, which always resolved to the published tag.
- Each workflow now checks out `dx-team-toolkit` at `github.workflow_sha` into a temporary `_dx-toolkit/` directory and uses the actions from there.
- This makes action changes testable on branches (PRs) and external callers always get actions matching the workflow version they reference.

## Why not local paths?

Using `./` local paths was not viable because these are reusable workflows called by **external repos**. `./` resolves in the **caller's** repository, which does not have the composite actions.

## How resolved?

The solution checks out `dx-team-toolkit` at `github.workflow_sha` into a `_dx-toolkit/` subdirectory. This SHA resolves to:
- The **feature branch commit** when testing within dx-team-toolkit PR
- The **`@v1` tag commit** when called by external repos, it's same behavior

## Why exclude?

An exclude step runs before any git operations (add-and-commit, create-pull-request, changesets/action, semantic-release) **to prevent the checkout from polluting diffs or generated PRs**. We have some actions and workflows creating PR or checking "changed files".

## Consumer impact

None. External repos calling these reusable workflows at `@v1` are unaffected. `github.workflow_sha` resolves to the same commit as `@v1`.
