### PR TITLE
fix: use job.workflow_sha for dx-team-toolkit self-checkout

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: fingerprintjs/dx-team-toolkit
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ job.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false

--- a/.github/workflows/preview-changeset-release.yml
+++ b/.github/workflows/preview-changeset-release.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: fingerprintjs/dx-team-toolkit
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ job.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: fingerprintjs/dx-team-toolkit
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ job.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: fingerprintjs/dx-team-toolkit
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ job.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
@@ -208,7 +208,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: fingerprintjs/dx-team-toolkit
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ job.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false

--- a/.github/workflows/release-server-sdk.yml
+++ b/.github/workflows/release-server-sdk.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: fingerprintjs/dx-team-toolkit
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ job.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: fingerprintjs/dx-team-toolkit
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ job.workflow_sha }}
           path: _dx-toolkit
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
- Replace `github.workflow_sha` with `job.workflow_sha` in reusable workflows that checkout local composite actions

### Context

#184 added a self-checkout step using `github.workflow_sha`, but in `workflow_call` jobs that resolves to the **caller** repo's workflow commit — not dx-team-toolkit's. This breaks every consumer at the "Checkout dx-team-toolkit actions" step.

Currently failing in [fingerprintjs/react PR #206](https://github.com/fingerprintjs/react/actions/runs/29906214905/job/88878187094?pr=206):

```
fatal: remote error: upload-pack: not our ref 8ebac149858ea50e377a9a3eb9944f83f48b4506
```

That SHA is the react PR merge commit, fetched against `fingerprintjs/dx-team-toolkit` where it doesn't exist. `job.workflow_sha` gives the reusable workflow's own commit instead.