### PR TITLE
ci: enable GitHub API commit mode in release workflows

### DIFF
--- a/.github/workflows/release-dx-packages.yml
+++ b/.github/workflows/release-dx-packages.yml
@@ -52,6 +52,7 @@ jobs:
           publish: pnpm changeset publish
           commit: 'chore(release): changeset created a new release'
           title: 'Release packages [changeset]'
+          commitMode: 'github-api'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -178,6 +178,7 @@ jobs:
           version: ${{ inputs.version-command }}
           commit: 'chore(release): changeset created a new release'
           title: 'Release [changeset]'
+          commitMode: 'github-api'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
   release:
@@ -254,6 +255,7 @@ jobs:
           version: ${{ inputs.version-command }}
           commit: 'chore(release): changeset created a new release'
           title: 'Release [changeset]'
+          commitMode: 'github-api'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # If useTrustedPublishing is true, use OIDC for npm authentication instead of NPM_TOKEN https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868 by passing an empty string


### PR DESCRIPTION
Specifying `commitMode: github-api` in changesets/action will sign the tags and commits using GPG key of the `GITHUB_TOKEN` owner.