### PR TITLE
chore: include generate command stdout in log output

### DIFF
--- a/.github/actions/update-sdk-schema/update-schema-for-tag.ts
+++ b/.github/actions/update-sdk-schema/update-schema-for-tag.ts
@@ -94,7 +94,7 @@ export async function updateSchemaForTag(
 
   console.info('Generating code')
   cp.execSync(generateCommand, {
-    stdio: 'pipe',
+    stdio: 'inherit',
     cwd,
   })
   console.info('Code generated')


### PR DESCRIPTION
- Update `updateSchemaForTag` to set `stdio` to `inherit` when running the code generation command to ensure that stdout is shown in the GH action logs.