### PR TITLE
fix(sdk-sync): check SDK out into subdir so tooling can't reach _dx-toolkit

### DIFF
--- a/.github/actions/update-sdk-schema/action.yml
+++ b/.github/actions/update-sdk-schema/action.yml
@@ -1,6 +1,9 @@
 name: 'Update Schema'
 description: 'Run schema updates using Node.js'
 inputs:
+  workingDirectory:
+    description: 'Directory of the SDK checkout. Schema paths and the generate command run here.'
+    default: '.'
   schemaSource:
     description: 'Source of the schema in OpenAPI release artifacts'
     required: true
@@ -62,6 +65,7 @@ runs:
     - name: Update schema
       shell: bash
       run: node ${{ github.action_path }}/update-schema.ts
+      working-directory: ${{ inputs.workingDirectory }}
       env:
         INPUT_SCHEMASOURCE: ${{ inputs.schemaSource }}
         INPUT_SCHEMAPATH: ${{ inputs.schemaPath }}

--- a/.github/workflows/update-server-side-sdk-schema.yml
+++ b/.github/workflows/update-server-side-sdk-schema.yml
@@ -122,6 +122,10 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: ${{ inputs.owner }}/${{ inputs.repository }}
+          # Check the SDK out into its own subdir so `_dx-toolkit` is a sibling, not a
+          # child. Tools run inside `sdk/` (lint, format, tests) can't reach the toolkit
+          # checkout, which lives at the workspace root.
+          path: sdk
 
       - name: 'Checkout dx-team-toolkit actions'
         uses: actions/checkout@v7
@@ -132,8 +136,8 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
-      - name: 'Exclude dx-team-toolkit checkout from git'
-        run: echo '_dx-toolkit/' >> .git/info/exclude
+      # No longer needed: `_dx-toolkit` is now outside the SDK checkout (sdk/), so the
+      # commit step scoped to sdk/ never picks it up.
 
       - name: Setup language
         uses: ./_dx-toolkit/.github/actions/setup-lang
@@ -144,14 +148,17 @@ jobs:
 
       - name: 'Setup pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          run_install: true
 
       - name: 'Install Node'
         uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.language == 'node' && inputs.language-version || 'lts/*' }}
           cache: 'pnpm'
+          cache-dependency-path: sdk/pnpm-lock.yaml
+
+      - name: 'Install SDK dependencies'
+        run: pnpm install
+        working-directory: sdk
 
       - name: Set git config
         run: |
@@ -160,6 +167,7 @@ jobs:
       - name: Update schema
         uses: ./_dx-toolkit/.github/actions/update-sdk-schema
         with:
+          workingDirectory: sdk
           schemaSource: ${{ inputs.schema-source }}
           schemaPath: ${{ inputs.schema-path }}
           examplesPath: ${{ inputs.examples-path }}
@@ -178,6 +186,7 @@ jobs:
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           add: '.'
+          cwd: sdk
           github_token: ${{ steps.app-token.outputs.token }}
           message: 'feat: sync OpenAPI schema to ${{ inputs.tag }}'
           push: 'false'
@@ -185,6 +194,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          path: sdk
           title: 'OpenAPI schema sync (${{ inputs.tag }})'
           body: 'Schema sync for [${{ inputs.tag }}](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/releases/tag/${{ inputs.tag }}) OpenAPI schema release.'
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
> **Draft** — proposes the central, cross-SDK fix. Needs testing on a real sync run (paths, pnpm cache, non-node SDKs) before merge.

## Problem

The reusable schema-sync workflow checks the SDK out at the **workspace root** and the toolkit into a sibling `_dx-toolkit/` dir, hidden from git via `.git/info/exclude`. Tools that walk the tree (`eslint .`, prettier, tests) **don't honor git ignores**, so they lint/scan the toolkit's own source and fail.

node-sdk hit this on the v3.5.0 sync — `pnpm generateTypes` → `eslint --max-warnings 0 .` tried to type-check `_dx-toolkit/.github/actions/**/*.ts` and errored (see [failing run](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/actions/runs/30560528447/job/90945566751)). It only reproduces when `_dx-toolkit/` is present, so nobody could hit it locally.

node-sdk shipped a per-repo ESLint ignore ([node-sdk#266](https://github.com/fingerprintjs/node-sdk/pull/266)) as the immediate unblock. This PR is the durable fix so **every** SDK is protected without each one patching its own config.

## Change

Check the SDK out into `sdk/` instead of the workspace root. Then `_dx-toolkit` is a **sibling**, not a child — any tool run inside `sdk/` can't reach it. No git-ignore trick needed.

- `path: sdk` on the SDK checkout.
- Removed the `.git/info/exclude` step (no longer needed; would also fail — no `.git` at root now).
- Install / cache / generate / commit / PR all scoped to `sdk/` (`working-directory`, `cache-dependency-path`, `cwd`, `path` inputs). Added a `workingDirectory` input to the `update-sdk-schema` action so `update-schema.ts` runs in the SDK dir.
- `schema-path` / `examples-path` inputs unchanged — still relative, now resolve under `sdk/`.

## Why not the alternatives

- **Remote action refs (`uses: org/repo/...@ref`)** — GitHub disallows `${{ }}` in `uses:`, so you can't pin to `@${{ job.workflow_sha }}`; you'd drift to a moving tag or a hardcoded sha. Loses the current version-lock.
- **Scope the lint (`eslint src tests`)** — the lint runs inside each SDK's own generate-command and every SDK has different folders; not centralizable.

## Test notes

Run the node sync against this branch (`update-server-side-sdk-schema.yml@<this-sha>`) and confirm: SDK lands in `sdk/`, `pnpm install` + generate + lint pass, commit and PR target the SDK repo. Spot-check one non-node SDK (go/java) since they share this workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSokJuixkDPNJjSfQez8e6)_