### PR TITLE
chore: remove `svelteSortOrder` from shared config

### DIFF
--- a/.changeset/quick-cycles-punch.md
+++ b/.changeset/quick-cycles-punch.md
@@ -1,0 +1,5 @@
+---
+"@fingerprintjs/prettier-config-dx-team": patch
+---
+
+remove `svelteSortOrder` option. Svelte projects should set `svelteSortOrder` by merging a config with the dx-team-toolkit config.

--- a/packages/prettier-config-dx-team/index.js
+++ b/packages/prettier-config-dx-team/index.js
@@ -9,7 +9,6 @@ module.exports = {
   bracketSpacing: true,
   bracketSameLine: false,
   arrowParens: 'always',
-  svelteSortOrder: 'options-scripts-markup-styles',
   proseWrap: 'never',
   overrides: [
     {


### PR DESCRIPTION
Remove the `svelteSortOrder` option from prettier config. When included in the prettier config and `prettier-plugin-svelte` is not a dev dependency, prettier emits a warning like:

```
[warn] Ignored unknown option { svelteSortOrder: "options-scripts-markup-styles" }.
```

The [svelte SDK config](https://github.com/fingerprintjs/svelte/blob/8622cfe9838265752592843127b9fcb1d82a931e/.prettierrc.js#L5) already is setting this option so it is safe to remove from the shared config.