### PR TITLE
Add unmarkReleaseAsLatest input to release-sdk-changesets workflow

### DIFF
--- a/.github/workflows/release-sdk-changesets.yml
+++ b/.github/workflows/release-sdk-changesets.yml
@@ -55,6 +55,11 @@ on:
         required: false
         default: false
         description: 'Whether to use trusted publishing for publishing packages'
+      unmarkReleaseAsLatest:
+        type: boolean
+        required: false
+        default: false
+        description: 'Set to true for releases cut from a non-default branch (e.g. a legacy/maintenance branch) so they don''t override the "Latest" badge on releases from the default branch.'
     secrets:
       APP_PRIVATE_KEY:
         description: 'GitHub App private key to request GitHub token for release process.'
@@ -261,18 +266,16 @@ jobs:
           # If useTrustedPublishing is true, use OIDC for npm authentication instead of NPM_TOKEN https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868 by passing an empty string
           NPM_TOKEN: ${{ inputs.useTrustedPublishing && '' || secrets.NPM_AUTH_TOKEN }}
 
-      - name: 'Upload files to GitHub release'
-        if: inputs.github-release-files != '' && steps.changesets-release.outputs.published == 'true'
+      # Only needed by the steps below: unmarking a release as latest (requires the tag to target
+      # `gh release edit`) and uploading release assets (requires the tag to target `gh release upload`).
+      # Marking a release as latest needs no action since new releases default to latest, so this step
+      # is skipped whenever neither of those steps will run.
+      - name: 'Compute published release tag'
+        id: release-tag
+        if: steps.changesets-release.outputs.published == 'true' && (inputs.unmarkReleaseAsLatest || inputs.github-release-files != '')
         env:
           PACKAGES: ${{ steps.changesets-release.outputs.publishedPackages }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Expand support for '**'
-          shopt -s globstar
-
-          # Convert no match patterns into the empty string to result in upload failures
-          shopt -s nullglob
-          
           # Check if changeset config has any ignored packages
           CHANGESET_CONFIG_IGNORE=$(jq -r .ignore ./.changeset/config.json | jq 'length')
 
@@ -286,6 +289,27 @@ jobs:
             # Changesets uses a different naming convention for multi-package repos
             TAG="${PACKAGE_NAME}@${VERSION}"
           fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: 'Unmark release as latest'
+        if: steps.changesets-release.outputs.published == 'true' && inputs.unmarkReleaseAsLatest
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh release edit "${{ steps.release-tag.outputs.tag }}" --latest=false
+
+      - name: 'Upload files to GitHub release'
+        if: inputs.github-release-files != '' && steps.changesets-release.outputs.published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Expand support for '**'
+          shopt -s globstar
+
+          # Convert no match patterns into the empty string to result in upload failures
+          shopt -s nullglob
+
+          TAG="${{ steps.release-tag.outputs.tag }}"
 
           IFS=',' read -ra GLOB_PATTERNS <<< "${{ inputs.github-release-files }}"
           for pattern in "${GLOB_PATTERNS[@]}"; do

--- a/README.md
+++ b/README.md
@@ -573,20 +573,19 @@ The workflow accepts the following input parameters:
 
 <!-- prettier-ignore -->
 
-| Input Parameter        | Required | Type    | Description                                                                                                 |
-|------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------|
-| `prepare-command`      | No       | String  | Command(s) to run for project preparation, such as installing dependencies.                                 |
-| `version-command`      | No       | String  | Command to run for project versioning                                                                       |
-| `publish-command`      | No       | String  | Command to run for project publishing                                                                       |
-| `language`             | Yes      | String  | Programming language for the project. Supported are `java`, `dotnet`, `node`, `python`, `golang` and `php`. |
-| `language-version`     | Yes      | String  | Version of the programming language to set up.                                                              |
-| `prepare-command`      | No       | String  | Command(s) to run for project preparation, such as installing dependencies.                                 |
-| `java-version`         | No       | String  | Version of Java to set up.                                                                                  |
-| `appId`                | Yes      | String  | GitHub App Id for creating GitHub token for the release                                                     |
-| `runnerAppId`          | No       | String  | GitHub App Id for creating PR.                                                                              |
-| `useTrustedPublishing` | No       | Boolean | Whether to use Trusted Publishing instead of NPM token for publishing the package.                          |
-| `github-release-files` | No       | String  | A comma-delimited list of glob patterns to identify the local files to attach to the GitHub release.        |
-| `unmarkReleaseAsLatest`| No       | Boolean | Set to `true` for releases cut from a non-default branch (e.g. a legacy/maintenance branch) so they don't override the "Latest" badge on releases from the default branch. Defaults to `false`. |
+| Input Parameter         | Required | Type    | Description                                                                                                                                                                                     |
+|-------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `prepare-command`       | No       | String  | Command(s) to run for project preparation, such as installing dependencies.                                                                                                                     |
+| `version-command`       | No       | String  | Command to run for project versioning                                                                                                                                                           |
+| `publish-command`       | No       | String  | Command to run for project publishing                                                                                                                                                           |
+| `language`              | Yes      | String  | Programming language for the project. Supported are `java`, `dotnet`, `node`, `python`, `golang` and `php`.                                                                                     |
+| `language-version`      | Yes      | String  | Version of the programming language to set up.                                                                                                                                                  |
+| `java-version`          | No       | String  | Version of Java to set up.                                                                                                                                                                      |
+| `appId`                 | Yes      | String  | GitHub App Id for creating GitHub token for the release                                                                                                                                         |
+| `runnerAppId`           | No       | String  | GitHub App Id for creating PR.                                                                                                                                                                  |
+| `useTrustedPublishing`  | No       | Boolean | Whether to use Trusted Publishing instead of NPM token for publishing the package.                                                                                                              |
+| `github-release-files`  | No       | String  | A comma-delimited list of glob patterns to identify the local files to attach to the GitHub release.                                                                                            |
+| `unmarkReleaseAsLatest` | No       | Boolean | Set to `true` for releases cut from a non-default branch (e.g. a legacy/maintenance branch) so they don't override the "Latest" badge on releases from the default branch. Defaults to `false`. |
 
 #### Workflow Secrets
 

--- a/README.md
+++ b/README.md
@@ -573,19 +573,19 @@ The workflow accepts the following input parameters:
 
 <!-- prettier-ignore -->
 
-| Input Parameter         | Required | Type    | Description                                                                                                                                                                                     |
-|-------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `prepare-command`       | No       | String  | Command(s) to run for project preparation, such as installing dependencies.                                                                                                                     |
-| `version-command`       | No       | String  | Command to run for project versioning                                                                                                                                                           |
-| `publish-command`       | No       | String  | Command to run for project publishing                                                                                                                                                           |
-| `language`              | Yes      | String  | Programming language for the project. Supported are `java`, `dotnet`, `node`, `python`, `golang` and `php`.                                                                                     |
-| `language-version`      | Yes      | String  | Version of the programming language to set up.                                                                                                                                                  |
-| `java-version`          | No       | String  | Version of Java to set up.                                                                                                                                                                      |
-| `appId`                 | Yes      | String  | GitHub App Id for creating GitHub token for the release                                                                                                                                         |
-| `runnerAppId`           | No       | String  | GitHub App Id for creating PR.                                                                                                                                                                  |
-| `useTrustedPublishing`  | No       | Boolean | Whether to use Trusted Publishing instead of NPM token for publishing the package.                                                                                                              |
-| `github-release-files`  | No       | String  | A comma-delimited list of glob patterns to identify the local files to attach to the GitHub release.                                                                                            |
-| `unmarkReleaseAsLatest` | No       | Boolean | Set to `true` for releases cut from a non-default branch (e.g. a legacy/maintenance branch) so they don't override the "Latest" badge on releases from the default branch. Defaults to `false`. |
+| Input Parameter         | Required | Type    | Description                                                                                                 |
+|-------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------|
+| `prepare-command`       | No       | String  | Command(s) to run for project preparation, such as installing dependencies.                                 |
+| `version-command`       | No       | String  | Command to run for project versioning                                                                       |
+| `publish-command`       | No       | String  | Command to run for project publishing                                                                       |
+| `language`              | Yes      | String  | Programming language for the project. Supported are `java`, `dotnet`, `node`, `python`, `golang` and `php`. |
+| `language-version`      | Yes      | String  | Version of the programming language to set up.                                                              |
+| `java-version`          | No       | String  | Version of Java to set up.                                                                                  |
+| `appId`                 | Yes      | String  | GitHub App Id for creating GitHub token for the release                                                     |
+| `runnerAppId`           | No       | String  | GitHub App Id for creating PR.                                                                              |
+| `useTrustedPublishing`  | No       | Boolean | Whether to use Trusted Publishing instead of NPM token for publishing the package.                          |
+| `github-release-files`  | No       | String  | A comma-delimited list of glob patterns to identify the local files to attach to the GitHub release.        |
+| `unmarkReleaseAsLatest` | No       | Boolean | Prevent this release from being marked as GitHub's "Latest". Defaults to `false`.                           |
 
 #### Workflow Secrets
 

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ The workflow accepts the following input parameters:
 | `runnerAppId`          | No       | String  | GitHub App Id for creating PR.                                                                              |
 | `useTrustedPublishing` | No       | Boolean | Whether to use Trusted Publishing instead of NPM token for publishing the package.                          |
 | `github-release-files` | No       | String  | A comma-delimited list of glob patterns to identify the local files to attach to the GitHub release.        |
+| `unmarkReleaseAsLatest`| No       | Boolean | Set to `true` for releases cut from a non-default branch (e.g. a legacy/maintenance branch) so they don't override the "Latest" badge on releases from the default branch. Defaults to `false`. |
 
 #### Workflow Secrets
 


### PR DESCRIPTION
## Why

GitHub Releases are repo-wide, not per-branch. `changesets/action` creates releases with no control over `make_latest`, so GitHub just flags whichever non-draft/non-prerelease release was published most recently as "Latest" — even if it came from a legacy/maintenance branch rather than the default branch.

This hit `fingerprintjs/node-sdk`: a routine release from its legacy `api-v3` branch became "Latest" on GitHub, ahead of the actual current release on `main`.

## What

Adds an `unmarkReleaseAsLatest` input (default `false` — no change for existing callers). When set to `true`, a new step runs `gh release edit TAG --latest=false` right after publish, so that branch's releases never override "Latest".

## Test plan

- [ ] Default behavior unchanged (new step only runs when `unmarkReleaseAsLatest: true` is explicitly set)
- [ ] `node-sdk`'s `api-v3` release workflow will pass `unmarkReleaseAsLatest: true` once merged
